### PR TITLE
Snapshot support.  API:

### DIFF
--- a/c_src/e_leveldb.cc
+++ b/c_src/e_leveldb.cc
@@ -244,7 +244,7 @@ ERL_NIF_TERM error_tuple(ErlNifEnv* env, ERL_NIF_TERM error, leveldb::Status& st
    transfer of the handle it returns, so it must be released before returning
    to erlang 
 */
-e_leveldb_snapshot_handle* make_snapshot_handle(e_leveldb_db_handle* db_handle,
+static e_leveldb_snapshot_handle* make_snapshot_handle(e_leveldb_db_handle* db_handle,
                                                 const leveldb::Snapshot* snapshot) 
 { 
     enif_keep_resource(db_handle);

--- a/c_src/e_leveldb.cc
+++ b/c_src/e_leveldb.cc
@@ -112,27 +112,32 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             opts.error_if_exists = (option[1] == ATOM_TRUE);
         else if (option[0] == ATOM_PARANOID_CHECKS) 
             opts.paranoid_checks = (option[1] == ATOM_TRUE);
-        else if (option[0] == ATOM_MAX_OPEN_FILES) {
+        else if (option[0] == ATOM_MAX_OPEN_FILES) 
+        {
             int max_open_files;
             if (enif_get_int(env, option[1], &max_open_files))
                 opts.max_open_files = max_open_files;
         }
-        else if (option[0] == ATOM_WRITE_BUFFER_SIZE) { 
+        else if (option[0] == ATOM_WRITE_BUFFER_SIZE) 
+        { 
             size_t write_buffer_sz;
             if (enif_get_ulong(env, option[1], &write_buffer_sz))
                 opts.write_buffer_size = write_buffer_sz;
         }
-        else if (option[0] == ATOM_BLOCK_SIZE) { 
+        else if (option[0] == ATOM_BLOCK_SIZE) 
+        { 
             size_t block_sz;
             if (enif_get_ulong(env, option[1], &block_sz)) 
                 opts.block_size = block_sz;
         }
-        else if (option[0] == ATOM_BLOCK_RESTART_INTERVAL) { 
+        else if (option[0] == ATOM_BLOCK_RESTART_INTERVAL) 
+        { 
             int block_restart_interval;
             if (enif_get_int(env, option[1], &block_restart_interval))
                 opts.block_restart_interval = block_restart_interval;
         }
-        else if (option[0] == ATOM_CACHE_SIZE) {
+        else if (option[0] == ATOM_CACHE_SIZE) 
+        {
             size_t cache_sz;
             if (enif_get_ulong(env, option[1], &cache_sz)) 
                 if (cache_sz != 0) 
@@ -263,13 +268,15 @@ static e_leveldb_snapshot_handle* make_snapshot_handle(e_leveldb_db_handle* db_h
 }
 
 int extract_handles(ErlNifEnv *env, ERL_NIF_TERM term, e_leveldb_db_handle **db_handle,
-                    e_leveldb_snapshot_handle **snapshot_handle) { 
+                    e_leveldb_snapshot_handle **snapshot_handle) 
+{ 
     *db_handle = 0;
     *snapshot_handle = 0;
     if (enif_get_resource(env, term, e_leveldb_db_RESOURCE, (void**)db_handle))
         return 1;
     else if (enif_get_resource(env, term, e_leveldb_snapshot_RESOURCE, 
-                               (void **)snapshot_handle)) { 
+                               (void **)snapshot_handle)) 
+    { 
         *db_handle = (*snapshot_handle)->db_handle;
         return 1;
     }
@@ -327,7 +334,8 @@ ERL_NIF_TERM e_leveldb_get(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         leveldb::ReadOptions opts;
         fold(env, argv[2], parse_read_option, opts);
 
-        if (snapshot_handle != 0) { 
+        if (snapshot_handle != 0) 
+        { 
             enif_mutex_lock(snapshot_handle->snapshot_lock);
             opts.snapshot = snapshot_handle->snapshot;
         }
@@ -396,13 +404,15 @@ ERL_NIF_TERM e_leveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
             leveldb::Status status = handle->db->Write(opts, &batch);
             if (status.ok())
             {
-                if (snapshot != 0) { 
+                if (snapshot != 0) 
+                { 
                     e_leveldb_snapshot_handle *snapshot_handle = make_snapshot_handle(handle, snapshot);
                     ERL_NIF_TERM snap_ref = enif_make_resource(env, snapshot_handle);
                     enif_release_resource(snapshot_handle);
                     return enif_make_tuple2(env, ATOM_OK, snap_ref);
                 }
-                else { 
+                else 
+                { 
                     return ATOM_OK;
                 }
             }

--- a/c_src/e_leveldb.cc
+++ b/c_src/e_leveldb.cc
@@ -448,7 +448,9 @@ ERL_NIF_TERM e_leveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
             // we got an already-created snapshot, keep a reference for the 
             // lifetime of the iterator.
             enif_keep_resource(snapshot_handle);
-        
+
+        enif_mutex_lock(snapshot_handle->snapshot_lock);
+
         opts.snapshot = snapshot_handle->snapshot;
         
         // Setup handle
@@ -464,6 +466,7 @@ ERL_NIF_TERM e_leveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 
         ERL_NIF_TERM result = enif_make_resource(env, itr_handle);
         enif_release_resource(itr_handle);
+        enif_mutex_unlock(snapshot_handle->snapshot_lock);
         return enif_make_tuple2(env, ATOM_OK, result);
     }
     else

--- a/c_src/e_leveldb.cc
+++ b/c_src/e_leveldb.cc
@@ -267,8 +267,8 @@ static e_leveldb_snapshot_handle* make_snapshot_handle(e_leveldb_db_handle* db_h
     return snapshot_handle;
 }
 
-int extract_handles(ErlNifEnv *env, ERL_NIF_TERM term, e_leveldb_db_handle **db_handle,
-                    e_leveldb_snapshot_handle **snapshot_handle) 
+static int extract_handles(ErlNifEnv *env, ERL_NIF_TERM term, e_leveldb_db_handle **db_handle,
+                           e_leveldb_snapshot_handle **snapshot_handle) 
 { 
     *db_handle = 0;
     *snapshot_handle = 0;
@@ -277,7 +277,9 @@ int extract_handles(ErlNifEnv *env, ERL_NIF_TERM term, e_leveldb_db_handle **db_
     else if (enif_get_resource(env, term, e_leveldb_snapshot_RESOURCE, 
                                (void **)snapshot_handle)) 
     { 
+        enif_mutex_lock((*snapshot_handle)->snapshot_lock);
         *db_handle = (*snapshot_handle)->db_handle;
+        enif_mutex_unlock((*snapshot_handle)->snapshot_lock);        
         return 1;
     }
     return 0;

--- a/c_src/e_leveldb.h
+++ b/c_src/e_leveldb.h
@@ -33,6 +33,8 @@ ERL_NIF_TERM e_leveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
 ERL_NIF_TERM e_leveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM e_leveldb_iterator_move(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM e_leveldb_iterator_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM e_leveldb_snapshot(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM e_leveldb_snapshot_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM e_leveldb_status(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 }
 


### PR DESCRIPTION
e_leveldb:snapshot(db_ref()) -> {ok, snapshot_ref()}.
e_leveldb:snapshot_close(snapshot_ref()) -> ok.
e_leveldb:get(db_ref()|snapshot_ref(), ...) -> ...
e_leveldb:iterator(db_ref()|snapshot_ref(), ..) -> ...
e_leveldb:write(..., [{return_snapshot, true}]) -> {ok, snapshot_ref()}.
e_leveldb:write(snapshot_ref(), ...) -> {error, read_only_snapshot}.

Also added support for e_leveldb:open() options:

{paranoid_checks, boolean()}
{max_open_files, pos_integer()}
{write_buffer_size, pos_integer()}
{block_size, pos_integer()}
{block_restart_interval, pos_integer()}
{cache_size, pos_integer()}
