### PR TITLE
BSD support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,19 @@
+
+all: compile
+
+compile:
+	./rebar compile
+
+test: compile
+	./rebar eunit
+
+clean:
+	./rebar clean
+
+c_src:
+	cd c_src/leveldb; $(MAKE)
+
+c_src_clean:
+	cd c_src/leveldb; $(MAKE) clean
+
+.PHONY: c_src

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,25 @@
+# This is a stub Makefile that invokes GNU make which will read the GNUmakefile
+# instead of this file. This provides compatability on systems where GNU make is
+# not the system 'make' (eg. most non-linux UNIXes).
 
-all: compile
+all:
+	@gmake all
 
-compile:
-	./rebar compile
+verbose:
+	@gmake verbose
 
-test: compile
-	./rebar eunit
+test:
+	@gmake test
+
+docs:
+	@gmake docs
+
+c_src: FORCE
+	@gmake c_src
+FORCE:
+
+c_src_clean:
+	@gmake c_src_clean
 
 clean:
-	./rebar clean
+	@gmake clean

--- a/c_src/leveldb/build_detect_platform
+++ b/c_src/leveldb/build_detect_platform
@@ -35,6 +35,21 @@ case `uname -s` in
         echo "PLATFORM_CFLAGS=-D_REENTRANT -DOS_FREEBSD"  >> build_config.mk
         echo "PLATFORM_LDFLAGS=-lpthread" >> build_config.mk
         ;;
+    NetBSD)
+        PLATFORM=OS_NETBSD
+        echo "PLATFORM_CFLAGS=-D_REENTRANT -DOS_NETBSD"  >> build_config.mk
+        echo "PLATFORM_LDFLAGS=-lpthread -lgcc_s" >> build_config.mk
+        ;;
+    OpenBSD)
+        PLATFORM=OS_OPENBSD
+        echo "PLATFORM_CFLAGS=-D_REENTRANT -DOS_OPENBSD"  >> build_config.mk
+        echo "PLATFORM_LDFLAGS=-lpthread" >> build_config.mk
+        ;;
+    DragonFly)
+        PLATFORM=OS_OPENBSD
+        echo "PLATFORM_CFLAGS=-D_REENTRANT -DOS_DRAGONFLYBSD"  >> build_config.mk
+        echo "PLATFORM_LDFLAGS=-lpthread" >> build_config.mk
+        ;;
     *)
         echo "Unknown platform!"
         exit 1

--- a/c_src/leveldb/port/port_posix.h
+++ b/c_src/leveldb/port/port_posix.h
@@ -16,6 +16,10 @@
   #else
     #define BIG_ENDIAN
   #endif
+#elif defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) ||\
+      defined(OS_DRAGONFLYBSD)
+  #include <sys/types.h>
+  #include <sys/endian.h>
 #else
   #include <endian.h>
 #endif
@@ -33,13 +37,15 @@
 #define IS_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
 #endif
 
-#if defined(OS_MACOSX) || defined(OS_SOLARIS) || defined(OS_FREEBSD)
+#if defined(OS_MACOSX) || defined(OS_SOLARIS) || defined(OS_FREEBSD) ||\
+    defined(OS_NETBSD) || defined(OS_OPENBSD) || defined(OS_DRAGONFLYBSD)
 #define fread_unlocked fread
 #define fwrite_unlocked fwrite
 #define fflush_unlocked fflush
 #endif
 
-#if defined(OS_MACOSX) || defined(OS_FREEBSD)
+#if defined(OS_MACOSX) || defined(OS_FREEBSD) ||\
+    defined(OS_OPENBSD) || defined(OS_DRAGONFLYBSD)
 #define fdatasync fsync
 #endif
 

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,9 @@
              %% Make sure to set -fPIC when compiling leveldb
              {"CFLAGS", "$CFLAGS -fPIC"},
              {"DRV_CFLAGS", "$DRV_CFLAGS -Werror -I c_src/leveldb/include"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++"}
+             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++"},
+             {"netbsd*", "DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++ -lgcc_s"}
              ]}.
 
-{pre_hooks, [{compile, "make -C c_src/leveldb"},
-             {clean, "make -C c_src/leveldb clean"}]}.
+{pre_hooks, [{compile, "make c_src"},
+             {clean, "make c_src_clean"}]}.


### PR DESCRIPTION
These patches make it possible to compile eleveldb on FreeBSD, NetBSD, OpenBSD and DragonFlyBSD. All the eunit tests pass and 'make check' for leveldb passes everywhere except for OpenBSD.

Unfortunately, because BSD make (except on FreeBSD) don't support the -C option, you need to tweak the rebar.config to call gmake instead. I don't know of a clean solution to this issue.
