### PR TITLE
Add snapshot support.

### DIFF
--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -30,6 +30,7 @@ extern "C" {
 ERL_NIF_TERM eleveldb_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_get(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM eleveldb_snapshot(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator_move(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);


### PR DESCRIPTION
Snapshots allow multiple read calls to act on the same version
of the database. This patch adds support for creating snapshots
and using them in each of the read calls.

I didn't realize till after I wrote this that @argv0 had done some work on a couple branches regarding snapshots. I poked through a bit but it looked like he was doing looking to support more than just a basic "read from snapshot". The one thing his code did remind me of is that this doesn't include support for the post_write_snapshot option. It could be added easily enough though.
