### PR TITLE
Lower default # of open files to 10; LevelDB default of 1k is just too hi

### DIFF
--- a/src/eleveldb.app.src
+++ b/src/eleveldb.app.src
@@ -7,5 +7,8 @@
                   kernel,
                   stdlib
                  ]},
-  {env, []}
+  {env, [
+         %% Max file handles to keep open by default
+         {max_open_files, 10}
+        ]}
  ]}.

--- a/src/eleveldb.app.src
+++ b/src/eleveldb.app.src
@@ -9,6 +9,8 @@
                  ]},
   {env, [
          %% Max file handles to keep open by default
-         {max_open_files, 10}
+         %% NOTE: 20 is the lowest value permitted by LevelDB; if you set it lower
+         %%       than this, LevelDB will bump override it up to 20
+         {max_open_files, 20}
         ]}
  ]}.


### PR DESCRIPTION
Lower default # of open files to 10; LevelDB default of 1k is just too high for most use-cases
