### PR TITLE
added explicit close function

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -86,6 +86,7 @@ static ErlNifFunc nif_funcs[] =
     {"open", 2, eleveldb_open},
     {"get", 3, eleveldb_get},
     {"write", 3, eleveldb_write},
+    {"close", 1, eleveldb_close},
     {"iterator", 2, eleveldb_iterator},
     {"iterator", 3, eleveldb_iterator},
     {"iterator_move", 2, eleveldb_iterator_move},
@@ -372,6 +373,17 @@ ERL_NIF_TERM eleveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 }
 
+ERL_NIF_TERM eleveldb_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    eleveldb_db_handle* db_handle;
+    if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle))
+    {
+        delete db_handle->db;
+	db_handle->db = NULL;
+    }
+    return ATOM_OK;
+}
+
 ERL_NIF_TERM eleveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     eleveldb_db_handle* db_handle;
@@ -620,7 +632,9 @@ static void eleveldb_db_resource_cleanup(ErlNifEnv* env, void* arg)
 {
     // Delete any dynamically allocated memory stored in eleveldb_db_handle
     eleveldb_db_handle* handle = (eleveldb_db_handle*)arg;
-    delete handle->db;
+    if (handle->db) {
+      delete handle->db;
+    }
 }
 
 static void eleveldb_itr_resource_cleanup(ErlNifEnv* env, void* arg)

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -288,6 +288,7 @@ ERL_NIF_TERM eleveldb_get(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     eleveldb_db_handle* handle;
     ErlNifBinary key;
     if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&handle) &&
+	handle->db &&
         enif_inspect_binary(env, argv[1], &key) &&
         enif_is_list(env, argv[2]))
     {
@@ -334,6 +335,7 @@ ERL_NIF_TERM eleveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     eleveldb_db_handle* handle;
     if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&handle) &&
+	handle->db &&
         enif_is_list(env, argv[1]) && // Actions
         enif_is_list(env, argv[2]))   // Opts
     {
@@ -376,7 +378,8 @@ ERL_NIF_TERM eleveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 ERL_NIF_TERM eleveldb_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     eleveldb_db_handle* db_handle;
-    if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle))
+    if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle) &&
+	db_handle->db)
     {
         delete db_handle->db;
 	db_handle->db = NULL;
@@ -388,6 +391,7 @@ ERL_NIF_TERM eleveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
 {
     eleveldb_db_handle* db_handle;
     if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle) &&
+	db_handle->db &&
         enif_is_list(env, argv[1])) // Options
     {
         // Increment references to db_handle for duration of the iterator
@@ -530,6 +534,7 @@ ERL_NIF_TERM eleveldb_status(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
     eleveldb_db_handle* db_handle;
     ErlNifBinary name_bin;
     if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle) &&
+	db_handle->db &&
         enif_inspect_binary(env, argv[1], &name_bin))
     {
         leveldb::Slice name((const char*)name_bin.data, name_bin.size);
@@ -605,7 +610,8 @@ ERL_NIF_TERM eleveldb_destroy(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
 ERL_NIF_TERM eleveldb_is_empty(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     eleveldb_db_handle* db_handle;
-    if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle))
+    if (enif_get_resource(env, argv[0], eleveldb_db_RESOURCE, (void**)&db_handle) &&
+	db_handle->db)
     {
         leveldb::ReadOptions opts;
         leveldb::Iterator* itr = db_handle->db->NewIterator(opts);
@@ -634,6 +640,7 @@ static void eleveldb_db_resource_cleanup(ErlNifEnv* env, void* arg)
     eleveldb_db_handle* handle = (eleveldb_db_handle*)arg;
     if (handle->db) {
       delete handle->db;
+      handle->db = NULL;
     }
 }
 

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -30,6 +30,7 @@ extern "C" {
 ERL_NIF_TERM eleveldb_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_get(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM eleveldb_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator_move(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -26,6 +26,7 @@
          put/4,
          delete/3,
          write/3,
+	 close/1,
          fold/4,
          fold_keys/4,
          status/2,
@@ -106,6 +107,10 @@ delete(Ref, Key, Opts) ->
 
 -spec write(db_ref(), write_actions(), write_options()) -> ok | {error, any()}.
 write(_Ref, _Updates, _Opts) ->
+    erlang:nif_error({error, not_loaded}).
+
+-spec close(db_ref()) -> ok.
+close(_Ref) ->
     erlang:nif_error({error, not_loaded}).
 
 -spec iterator(db_ref(), read_options()) -> {ok, itr_ref()}.
@@ -192,6 +197,11 @@ open_test() ->
     ok = ?MODULE:put(Ref, <<"abc">>, <<"123">>, []),
     {ok, <<"123">>} = ?MODULE:get(Ref, <<"abc">>, []),
     not_found = ?MODULE:get(Ref, <<"def">>, []).
+
+close_test() ->
+    os:cmd("rm -rf /tmp/eleveldb.close.test"),
+    {ok, Ref} = open("/tmp/eleveldb.close.test", [{create_if_missing, true}]),
+    ok = ?MODULE:close(Ref).
 
 fold_test() ->
     os:cmd("rm -rf /tmp/eleveldb.fold.test"),

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -201,7 +201,11 @@ open_test() ->
 close_test() ->
     os:cmd("rm -rf /tmp/eleveldb.close.test"),
     {ok, Ref} = open("/tmp/eleveldb.close.test", [{create_if_missing, true}]),
-    ok = ?MODULE:close(Ref).
+    ok = ?MODULE:close(Ref),
+    ?assertError(badarg, ?MODULE:put(Ref, <<"a">>, <<"b">>, [])),
+    ?assertError(badarg, ?MODULE:get(Ref, <<"a">>, [])),
+    ?assertError(badarg, ?MODULE:status(Ref, <<"a">>)),
+    ?assertError(badarg, ?MODULE:iterator(Ref, [])).
 
 fold_test() ->
     os:cmd("rm -rf /tmp/eleveldb.fold.test"),

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -198,14 +198,7 @@ open_test() ->
     {ok, <<"123">>} = ?MODULE:get(Ref, <<"abc">>, []),
     not_found = ?MODULE:get(Ref, <<"def">>, []).
 
-close_test() ->
-    os:cmd("rm -rf /tmp/eleveldb.close.test"),
-    {ok, Ref} = open("/tmp/eleveldb.close.test", [{create_if_missing, true}]),
-    ok = ?MODULE:close(Ref),
-    ?assertError(badarg, ?MODULE:put(Ref, <<"a">>, <<"b">>, [])),
-    ?assertError(badarg, ?MODULE:get(Ref, <<"a">>, [])),
-    ?assertError(badarg, ?MODULE:status(Ref, <<"a">>)),
-    ?assertError(badarg, ?MODULE:iterator(Ref, [])).
+
 
 fold_test() ->
     os:cmd("rm -rf /tmp/eleveldb.fold.test"),
@@ -269,6 +262,20 @@ compression_test() ->
     CompressedSize = Size("/tmp/eleveldb.compress.1"),
     ?assert(UncompressedSize > CompressedSize).
 
+close_test() ->
+    os:cmd("rm -rf /tmp/eleveldb.close.test"),
+    {ok, Ref} = open("/tmp/eleveldb.close.test", [{create_if_missing, true}]),
+    ok = ?MODULE:close(Ref),
+    ?assertError(badarg, ?MODULE:put(Ref, <<"a">>, <<"b">>, [])),
+    ?assertError(badarg, ?MODULE:get(Ref, <<"a">>, [])),
+    ?assertError(badarg, ?MODULE:status(Ref, <<"a">>)),
+    ?assertError(badarg, ?MODULE:iterator(Ref, [])).
+
+close_with_iterator_test() ->
+    os:cmd("rm -rf /tmp/eleveldb.close_itr.test"),
+    {ok, Ref} = open("/tmp/eleveldb.close_itr.test", [{create_if_missing, true}]),
+    {ok, _Itr} = ?MODULE:iterator(Ref, []),
+    ?assertError(badarg, ?MODULE:close(Ref)).
 
 -ifdef(EQC).
 


### PR DESCRIPTION
Needed the ability to close a database independent of NIF cleanup / beam GC.
