### PR TITLE
Modified c_src/build_deps.sh to remove bash dependency and add FreeBSD compatibility

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 LEVELDB_VSN="b921bc7197c50e47a01608d8728ff3dcacfe0c30" # Mar 15 merge of mainline
 SNAPPY_VSN="1.0.4"
@@ -6,10 +6,20 @@ SNAPPY_VSN="1.0.4"
 set -e
 
 if [ `basename $PWD` != "c_src" ]; then
-    pushd c_src
+    # originally "pushd c_src" of bash
+    # but no need to use directory stack push here
+    cd c_src
 fi
 
 BASEDIR="$PWD"
+
+# detecting gmake and if exists use it
+# if not use make
+# (code from github.com/tuncer/re2/c_src/build_deps.sh
+which gmake 1>/dev/null 2>/dev/null && MAKE=gmake
+MAKE=${MAKE:-make}
+
+# Changed "make" to $MAKE
 
 case "$1" in
     clean)
@@ -21,7 +31,7 @@ case "$1" in
         export LDFLAGS="$LDFLAGS -L $BASEDIR/system/lib"
         export LD_LIBRARY_PATH="$BASEDIR/system/lib:$LD_LIBRARY_PATH"
 
-        (cd leveldb && make check)
+        (cd leveldb && $MAKE check)
 
         ;;
     *)
@@ -30,7 +40,7 @@ case "$1" in
             (cd snappy-$SNAPPY_VSN && ./configure --prefix=$BASEDIR/system --with-pic)
         fi
 
-        (cd snappy-$SNAPPY_VSN && make && make install)
+        (cd snappy-$SNAPPY_VSN && $MAKE && $MAKE install)
 
         export CFLAGS="$CFLAGS -I $BASEDIR/system/include"
         export LDFLAGS="$LDFLAGS -L $BASEDIR/system/lib"
@@ -41,7 +51,7 @@ case "$1" in
             (cd leveldb && git checkout $LEVELDB_VSN)
         fi
 
-        (cd leveldb && make all)
+        (cd leveldb && $MAKE all)
 
         ;;
 esac


### PR DESCRIPTION
Modification details:
- changed the shebang entry from /bin/bash to /bin/sh to remove unnecessary bash dependency
- changed the "pushd" to "cd", because there's no need to push pwd into directory stack in this script
- added Tuncer Ayaz's script of detecting "gmake" command so that systems which have gmake for GNU Make will use it instead of make (NOTE: $MAKE replaces "make" now).
