### PR TITLE
Use a /bin/sh workaround to fix building on solaris

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# /bin/sh on Solaris is not a POSIX compatible shell, but /usr/bin/ksh is.
+if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
+    POSIX_SHELL="true"
+    export POSIX_SHELL
+    exec /usr/bin/ksh $0 $@
+fi
+unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
+
 LEVELDB_VSN="b921bc7197c50e47a01608d8728ff3dcacfe0c30" # Mar 15 merge of mainline
 SNAPPY_VSN="1.0.4"
 


### PR DESCRIPTION
The FreeBSD fix recently merged breaks solaris, because the shebang was changed to #!/bin/sh.

@jaredmorrow 
