### PR TITLE
Add eleveldb:close 

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -634,7 +634,7 @@ ERL_NIF_TERM eleveldb_iterator_close(ErlNifEnv* env, int argc, const ERL_NIF_TER
         enif_mutex_unlock(itr_handle->itr_lock);
         enif_mutex_unlock(itr_handle->db_handle->db_lock);
 
-        enif_release_resource(itr_handle->db_handle);
+        enif_release_resource(itr_handle->db_handle); // matches keep in eleveldb_iterator()
 
         return ATOM_OK;
     }
@@ -791,7 +791,7 @@ static void eleveldb_itr_resource_cleanup(ErlNifEnv* env, void* arg)
         free_itr(itr_handle);
 
         enif_mutex_unlock(itr_handle->db_handle->db_lock);
-        enif_release_resource(itr_handle->db_handle);
+        enif_release_resource(itr_handle->db_handle);  // matches keep in eleveldb_iterator()
     }
 
     enif_mutex_destroy(itr_handle->itr_lock);

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -784,7 +784,10 @@ static void eleveldb_itr_resource_cleanup(ErlNifEnv* env, void* arg)
     {
         enif_mutex_lock(itr_handle->db_handle->db_lock);
 
-        itr_handle->db_handle->iters->erase(itr_handle);
+        if (itr_handle->db_handle->iters)
+        {
+            itr_handle->db_handle->iters->erase(itr_handle);
+        }
         free_itr(itr_handle);
 
         enif_mutex_unlock(itr_handle->db_handle->db_lock);

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -28,6 +28,7 @@ extern "C" {
 
 // Prototypes
 ERL_NIF_TERM eleveldb_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM eleveldb_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_get(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM eleveldb_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -280,8 +280,8 @@ destroy_test() ->
     {ok, Ref} = open("/tmp/eleveldb.destroy.test", [{create_if_missing, true}]),
     ok = ?MODULE:put(Ref, <<"def">>, <<"456">>, []),
     {ok, <<"456">>} = ?MODULE:get(Ref, <<"def">>, []),
-    ok = ?MODULE:destroy("/tmp/eleveldb.destroy.test", []),
     close(Ref),
+    ok = ?MODULE:destroy("/tmp/eleveldb.destroy.test", []),
     {error, {db_open, _}} = open("/tmp/eleveldb.destroy.test", [{error_if_exists, true}]).
 
 compression_test() ->

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -22,6 +22,7 @@
 -module(eleveldb).
 
 -export([open/2,
+         close/1,
          get/3,
          put/4,
          delete/3,
@@ -94,6 +95,10 @@ init() ->
 
 -spec open(string(), open_options()) -> {ok, db_ref()} | {error, any()}.
 open(_Name, _Opts) ->
+    erlang:nif_error({error, not_loaded}).
+
+-spec close(db_ref()) -> ok | {error, any()}.
+close(_Ref) ->
     erlang:nif_error({error, not_loaded}).
 
 -spec get(db_ref(), binary(), read_options()) -> {ok, binary()} | not_found | {error, any()}.
@@ -270,6 +275,7 @@ destroy_test() ->
     ok = ?MODULE:put(Ref, <<"def">>, <<"456">>, []),
     {ok, <<"456">>} = ?MODULE:get(Ref, <<"def">>, []),
     ok = ?MODULE:destroy("/tmp/eleveldb.destroy.test", []),
+    close(Ref),
     {error, {db_open, _}} = open("/tmp/eleveldb.destroy.test", [{error_if_exists, true}]).
 
 compression_test() ->

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -139,6 +139,8 @@ iterator_close(_IRef) ->
 
 -type fold_fun() :: fun(({Key::binary(), Value::binary()}, any()) -> any()).
 
+%% Fold over the keys and values in the database
+%% will throw an exception if the database is closed while the fold runs
 -spec fold(db_ref(), fold_fun(), any(), read_options()) -> any().
 fold(Ref, Fun, Acc0, Opts) ->
     {ok, Itr} = iterator(Ref, Opts),
@@ -146,6 +148,8 @@ fold(Ref, Fun, Acc0, Opts) ->
 
 -type fold_keys_fun() :: fun((Key::binary(), any()) -> any()).
 
+%% Fold over the keys in the database
+%% will throw an exception if the database is closed while the fold runs
 -spec fold_keys(db_ref(), fold_keys_fun(), any(), read_options()) -> any().
 fold_keys(Ref, Fun, Acc0, Opts) ->
     {ok, Itr} = iterator(Ref, Opts, keys_only),
@@ -210,6 +214,8 @@ do_fold(Itr, Fun, Acc0, Opts) ->
         iterator_close(Itr)
     end.
 
+fold_loop({error, iterator_closed}, _Itr, _Fun, Acc0) ->
+    throw({iterator_closed, Acc0});
 fold_loop({error, invalid_iterator}, _Itr, _Fun, Acc0) ->
     Acc0;
 fold_loop({ok, K}, Itr, Fun, Acc0) ->
@@ -305,6 +311,19 @@ compression_test() ->
 	Log1Option = MatchCompressOption("/tmp/eleveldb.compress.1/LOG", "1"),
 	?assert(Log0Option =:= match andalso Log1Option =:= match).
 
+
+close_test() ->
+    os:cmd("rm -rf /tmp/eleveldb.close.test"),
+    {ok, Ref} = open("/tmp/eleveldb.close.test", [{create_if_missing, true}]),
+    ?assertEqual(ok, close(Ref)),
+    ?assertEqual({error, einval}, close(Ref)).
+
+close_fold_test() ->
+    os:cmd("rm -rf /tmp/eleveldb.close_fold.test"),
+    {ok, Ref} = open("/tmp/eleveldb.close_fold.test", [{create_if_missing, true}]),
+    ok = eleveldb:put(Ref, <<"k">>,<<"v">>,[]),
+    ?assertException(throw, {iterator_closed, ok}, % ok is returned by close as the acc
+                     eleveldb:fold(Ref, fun(_,A) -> eleveldb:close(Ref) end, undefined, [])).
 
 -ifdef(EQC).
 


### PR DESCRIPTION
Added to fix the missing MANIFEST race around handoff / destroy / open.

This adds a mutex to the db_handle object to make sure it had not been closed from underneath any operations.  All iterators created from the DB Ref are tracked and cleaned up when the database is closed.  Any folds will throw exceptions if in progress and any other operation should return {error, einval} (modelled after the socket library).

As well as adding close, this also fixes a use-after-free bug to do with garbage collection.  Although the NIF resources are released in the previous code, the order that the cleanup run is determined by the position in the heap by the garbage collector.  The two examples show different ordering of cleanup.

```

11> spawn(fun() -> {ok, Db} = eleveldb:open("/tmp/t.db",[{create_if_missing, true}]), eleveldb:put(Db, <<"k">>,<<"v">>,[]), eleveldb:fold(Db, fun(_,_) -> lists:seq(1,10000) end, undefined, []) end).
**** db 0x7f8b220fda28 cleanup
**** iterator 0x1e261ae8 cleanup for db 0x7f8b220fda28
<0.54.0>
12> spawn(fun() -> {ok, Db} = eleveldb:open("/tmp/t.db",[{create_if_missing, true}]), eleveldb:put(Db, <<"k">>,<<"v">>,[]), eleveldb:fold(Db, fun(_,_) -> lists:seq(1,10000) end, undefined, []), garbage_collect() end).
**** iterator 0x7f8b220fca58 cleanup for db 0x7f8b220fc9c0
**** db 0x7f8b220fc9c0 cleanup
```

The code needs to be benchmarked before merging which we'll work on, but can be reviewed before then.
