### PR TITLE
Change which can specify rebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
+REBAR := ./rebar
 
 all: compile
 
 compile:
-	./rebar compile
+	$(REBAR) compile
 
 test: compile
-	./rebar eunit
+	$(REBAR) eunit
 
 clean:
-	./rebar clean
+	$(REBAR) clean


### PR DESCRIPTION
Some users may use not rebar attached but installed in the system.
This makes a change which can specify rebar.

Signed-off-by: Nobuhiro Iwamatsu iwamatsu@debian.org
