### PR TITLE
Export iterator/3 so users can iterate over just keys

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -38,6 +38,7 @@
          validate_options/2]).
 
 -export([iterator/2,
+         iterator/3,
          iterator_move/2,
          iterator_close/1]).
 


### PR DESCRIPTION
I've been playing with leveldb iterators (not through `eleveldb:fold`), and would find it useful to be able to iterator through keys only. I don't know if there's a better way to deal with the 3rd argument to `iterator` only being able to be `keys_only`. If you pass in some other atom, it doesn't blow up, but just silently ignores that arg.
