### PR TITLE
OpenBSD needs inc/dec_and_fetch templates for size_t

### DIFF
--- a/c_src/detail.hpp
+++ b/c_src/detail.hpp
@@ -90,7 +90,7 @@ inline uint32_t inc_and_fetch(volatile uint32_t *ptr)
 #endif
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 template <>
 inline size_t inc_and_fetch(volatile size_t *ptr)
 {
@@ -121,7 +121,7 @@ inline uint32_t dec_and_fetch(volatile uint32_t *ptr)
 #endif
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 template <>
 inline size_t dec_and_fetch(volatile size_t *ptr)
 {


### PR DESCRIPTION
This is needed to produce an eleveldb.so that loads correctly on OpenBSD.
