### PR TITLE
Export types to avoid opaque type warning in R16.

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -41,6 +41,9 @@
          iterator_move/2,
          iterator_close/1]).
 
+-export_type([db_ref/0,
+              itr_ref/0]).
+
 -on_load(init/0).
 
 -ifdef(TEST).


### PR DESCRIPTION
@vinoski 
