### PR TITLE
fix build on s390

### DIFF
--- a/c_src/detail.hpp
+++ b/c_src/detail.hpp
@@ -90,7 +90,7 @@ inline uint32_t inc_and_fetch(volatile uint32_t *ptr)
 #endif
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || (defined(__s390__) && !defined(__s390x__))
 template <>
 inline size_t inc_and_fetch(volatile size_t *ptr)
 {
@@ -121,7 +121,7 @@ inline uint32_t dec_and_fetch(volatile uint32_t *ptr)
 #endif
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || (defined(__s390__) && !defined(__s390x__))
 template <>
 inline size_t dec_and_fetch(volatile size_t *ptr)
 {


### PR DESCRIPTION
This fixes building on s390x. It still fails to pass the test but this might be a different issue.

http://s390.koji.fedoraproject.org/koji/getfile?taskID=1012323&name=build.log
