### PR TITLE
add get-deps and rm-deps makefile targets, clean doesn't delete leveldb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 
 all: compile
 
+get-deps:
+	./c_src/build_deps.sh get-deps
+
+rm-deps:
+	./c_src/build_deps.sh rm-deps
+
 compile:
 	./rebar compile
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -31,8 +31,15 @@ MAKE=${MAKE:-make}
 # Changed "make" to $MAKE
 
 case "$1" in
-    clean)
+    rm-deps)
         rm -rf leveldb system snappy-$SNAPPY_VSN
+        ;;
+
+    clean)
+        rm -rf system snappy-$SNAPPY_VSN
+        if [ -d leveldb ]; then
+            gmake -C leveldb clean
+        fi
         ;;
 
     test)


### PR DESCRIPTION
add get-deps and rm-deps makefile targets to download/delete dependencies (leveldb), target 'clean' doesn't delete leveldb if there
