### PR TITLE
Re-export eleveldb:iterator/3

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -38,6 +38,7 @@
          validate_options/2]).
 
 -export([iterator/2,
+         iterator/3,
          iterator_move/2,
          iterator_close/1]).
 


### PR DESCRIPTION
This was originally exported in
e6ae8c5abd0d41345311ae895b349a8cb31d744e,
but was accidently undone in 025a3602a55845d1f4f3940158a627772d4e9bd0.
