### PR TITLE
update to safer defaults

### DIFF
--- a/src/eleveldb.app.src
+++ b/src/eleveldb.app.src
@@ -14,6 +14,10 @@
          {max_open_files, 20},
 
          %% Use bloom filter support by default
-         {use_bloomfilter, true}
+         {use_bloomfilter, true},
+
+         %% make sure that we're maximally safe by default
+         {verify_checksums, true},    
+         {paranoid_checks, true}
         ]}
  ]}.


### PR DESCRIPTION
It's my understanding that verify_checksums won't work unless paranoid_checks is also enabled.  This change should make them be on for everyone unless they're intentionally disabled.

This does include people who're upgrading, but I figured that if it is our intention to force the use of these going forward, it's better to deal with the issues this might potentially cause sooner rather than later.

cc @matthewvon @jonmeredith 
