### PR TITLE
Fix spec for async_get

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -130,10 +130,7 @@ close(Ref) ->
 close_int(_Ref) ->
     erlang:nif_error({error, not_loaded}).
 
--spec async_get(reference(), db_ref(), binary(), read_options()) ->
-                                {reference(), { error, einval}} |
-                                {reference(), not_found} |
-                                {reference(), ok, binary()}.
+-spec async_get(reference(), db_ref(), binary(), read_options()) -> ok.
 async_get(_CallerRef, _Dbh, _Key, _Opts) ->
     erlang:nif_error({error, not_loaded}).
 


### PR DESCRIPTION
This is an async get, the previously defined spec was conflating the
message being sent to the request pid with the term actually returned
by the function call.  The later can only be the atom `ok` or a
`badarg` exception.
