### PR TITLE
Mv clean overlaps

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="1.4.1"
+LEVELDB_VSN="mv-clean-overlaps"
 
 SNAPPY_VSN="1.0.4"
 

--- a/test/cacheleak.erl
+++ b/test/cacheleak.erl
@@ -30,7 +30,7 @@ cacheleak_test_() ->
                               [] = os:cmd("rm -rf /tmp/eleveldb.cacheleak.test"),
                               Blobs = [{<<I:128/unsigned>>, compressible_bytes(10240)} ||
                                           I <- lists:seq(1, 10000)],
-                              cacheleak_loop(10, Blobs, 350000)
+                              cacheleak_loop(10, Blobs, 400000)
                       end}.
 
 %% It's very important for this test that the data is compressible. Otherwise,

--- a/test/cacheleak.erl
+++ b/test/cacheleak.erl
@@ -49,11 +49,11 @@ cacheleak_loop(Count, Blobs, MaxFinalRSS) ->
 
                 {ok, Ref} = eleveldb:open("/tmp/eleveldb.cacheleak.test",
                                           [{create_if_missing, true},
-                                           {cache_size, 83886080}]),
+                                           {cache_size, 83886080},
+                                           {write_buffer_size, 45000000}]),
                 [ok = eleveldb:put(Ref, I, B, []) || {I, B} <- Blobs],
                 eleveldb:fold(Ref, fun({_K, _V}, A) -> A end, [], [{fill_cache, true}]),
                 [{ok, B} = eleveldb:get(Ref, I, []) || {I, B} <- Blobs],
-                ok = eleveldb:close(Ref),
                 erlang:garbage_collect(),
                 io:format(user, "RSS1: ~p\n", [rssmem()])
         end,


### PR DESCRIPTION
Delving into the cachetest.erl unit test revealed two things:  the test is a royal pain, and due to its pain we missed an actual cache memory leak.  This branch works the royal pain and the leveldb mv-clean-overlaps works the memory leak.
