### PR TITLE
Specify the Snappy libdir install location

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -62,7 +62,7 @@ case "$1" in
     *)
         if [ ! -d snappy-$SNAPPY_VSN ]; then
             tar -xzf snappy-$SNAPPY_VSN.tar.gz
-            (cd snappy-$SNAPPY_VSN && ./configure --prefix=$BASEDIR/system --with-pic)
+            (cd snappy-$SNAPPY_VSN && ./configure --prefix=$BASEDIR/system --libdir=$BASEDIR/system/lib --with-pic)
         fi
 
         (cd snappy-$SNAPPY_VSN && $MAKE && $MAKE install)


### PR DESCRIPTION
Addresses: basho/eleveldb#64

It was reported that on OpenSUSE snappy's configure installs to
the wrong location despite the default setting in snappy's
configure.  This change merely forces the issue to the
expected location.
