### PR TITLE
Mv flexcache

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.0pre1"
+LEVELDB_VSN="mv-flexcache"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="mv-flexcache"
+LEVELDB_VSN="b4f590fd44e865ef6fac0c7886ea324c3534b846"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -387,8 +387,8 @@ async_open(
     // convert total_leveldb_mem to byte count if it arrived as percent
     //  This happens now because there is no guarantee as to when the total_memory
     //  value would be read relative to total_leveldb_mem_percent in the option fold
-    if (0 < opts.total_leveldb_mem && opts.total_leveldb_mem<=100)
-        opts.total_leveldb_mem=(opts.total_leveldb_mem * gCurrentTotalMemory)/100;
+    if (0 < opts->total_leveldb_mem && opts->total_leveldb_mem<=100)
+        opts->total_leveldb_mem=(opts->total_leveldb_mem * gCurrentTotalMemory)/100;
 
     eleveldb::WorkTask *work_item = new eleveldb::OpenTask(env, caller_ref,
                                                               db_name, opts);

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -119,6 +119,7 @@ ERL_NIF_TERM ATOM_KEYS_ONLY;
 ERL_NIF_TERM ATOM_COMPRESSION;
 ERL_NIF_TERM ATOM_ERROR_DB_REPAIR;
 ERL_NIF_TERM ATOM_USE_BLOOMFILTER;
+ERL_NIF_TERM ATOM_TOTAL_LEVELDB_MEM;
 
 }   // namespace eleveldb
 
@@ -247,6 +248,17 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             if (option[1] == eleveldb::ATOM_TRUE || enif_get_ulong(env, option[1], &bfsize))
             {
                 opts.filter_policy = leveldb::NewBloomFilterPolicy2(bfsize);
+            }
+        }
+        else if (option[0] == eleveldb::ATOM_TOTAL_LEVELDB_MEM)
+        {
+            uint64_t memory_sz;
+            if (enif_get_uint64(env, option[1], &memory_sz))
+            {
+                if (memory_sz != 0)
+                 {
+                     opts.total_leveldb_mem = memory_sz;
+                 }
             }
         }
     }
@@ -1006,6 +1018,7 @@ try
     ATOM(eleveldb::ATOM_KEYS_ONLY, "keys_only");
     ATOM(eleveldb::ATOM_COMPRESSION, "compression");
     ATOM(eleveldb::ATOM_USE_BLOOMFILTER, "use_bloomfilter");
+    ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_leveldb_mem");
 
 #undef ATOM
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -1039,9 +1039,9 @@ try
     ATOM(eleveldb::ATOM_KEYS_ONLY, "keys_only");
     ATOM(eleveldb::ATOM_COMPRESSION, "compression");
     ATOM(eleveldb::ATOM_USE_BLOOMFILTER, "use_bloomfilter");
-    ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_memory");
+    ATOM(eleveldb::ATOM_TOTAL_MEMORY, "total_memory");
     ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_leveldb_mem");
-    ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_leveldb_mem_percent");
+    ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM_PERCENT, "total_leveldb_mem_percent");
     ATOM(eleveldb::ATOM_IS_INTERNAL_DB, "is_internal_db");
 
 #undef ATOM

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -234,7 +234,9 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             unsigned long memory_sz;
             if (enif_get_ulong(env, option[1], &memory_sz))
             {
-                // ignoring memory size below 2G, going with defaults
+                // ignoring memory size below 1G, going with defaults
+                //  (because Erlang/Riak need 1G to themselves making
+                //   percentage of memory unreliable)
                 if (1024*1024*1024L < memory_sz)
                 {
                     gCurrentTotalMemory = memory_sz;

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -392,6 +392,11 @@ async_open(
     if (0 < opts->total_leveldb_mem && opts->total_leveldb_mem<=100)
         opts->total_leveldb_mem=(opts->total_leveldb_mem * gCurrentTotalMemory)/100;
 
+    // it could be that we are only activating internal databases (or they come up first)
+    //  give them all RAM knowing flexcache will reduce it to 20% or so
+    if (0 == opts->total_leveldb_mem && opts->is_internal_db)
+        opts->total_leveldb_mem = gCurrentTotalMemory;
+
     eleveldb::WorkTask *work_item = new eleveldb::OpenTask(env, caller_ref,
                                                               db_name, opts);
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -229,8 +229,10 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
         }
         else if (option[0] == eleveldb::ATOM_TOTAL_MEMORY)
         {
-            uint64_t memory_sz;
-            if (enif_get_uint64(env, option[1], &memory_sz))
+            // NOTE: uint64_t memory_sz and enif_get_uint64() do NOT compile
+            // correctly on some platforms.  Why?  because it's Erlang.
+            unsigned long memory_sz;
+            if (enif_get_ulong(env, option[1], &memory_sz))
             {
                 // ignoring memory size below 2G, going with defaults
                 if (1024*1024*1024L < memory_sz)
@@ -247,8 +249,8 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
         }
         else if (option[0] == eleveldb::ATOM_TOTAL_LEVELDB_MEM)
         {
-            uint64_t memory_sz;
-            if (enif_get_uint64(env, option[1], &memory_sz))
+            unsigned long memory_sz;
+            if (enif_get_ulong(env, option[1], &memory_sz))
             {
                 if (memory_sz != 0)
                  {
@@ -258,8 +260,8 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
         }
         else if (option[0] == eleveldb::ATOM_TOTAL_LEVELDB_MEM_PERCENT)
         {
-            uint64_t memory_sz;
-            if (enif_get_uint64(env, option[1], &memory_sz))
+            unsigned long memory_sz;
+            if (enif_get_ulong(env, option[1], &memory_sz))
             {
                 if (0 < memory_sz && memory_sz <= 100)
                  {

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -120,6 +120,7 @@ ERL_NIF_TERM ATOM_COMPRESSION;
 ERL_NIF_TERM ATOM_ERROR_DB_REPAIR;
 ERL_NIF_TERM ATOM_USE_BLOOMFILTER;
 ERL_NIF_TERM ATOM_TOTAL_LEVELDB_MEM;
+ERL_NIF_TERM ATOM_IS_INTERNAL_DB;
 
 }   // namespace eleveldb
 
@@ -262,6 +263,13 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
                      opts.total_leveldb_mem = memory_sz;
                  }
             }
+        }
+        else if (option[0] == eleveldb::ATOM_IS_INTERNAL_DB)
+        {
+            if (option[1] == eleveldb::ATOM_TRUE)
+                opts.is_internal_db = true;
+            else
+                opts.is_internal_db = false;
         }
     }
 
@@ -1021,6 +1029,7 @@ try
     ATOM(eleveldb::ATOM_COMPRESSION, "compression");
     ATOM(eleveldb::ATOM_USE_BLOOMFILTER, "use_bloomfilter");
     ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_leveldb_mem");
+    ATOM(eleveldb::ATOM_IS_INTERNAL_DB, "is_internal_db");
 
 #undef ATOM
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -219,6 +219,7 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             if (enif_get_int(env, option[1], &block_restart_interval))
                 opts.block_restart_interval = block_restart_interval;
         }
+#if 0
         else if (option[0] == eleveldb::ATOM_CACHE_SIZE)
         {
             unsigned long cache_sz;
@@ -228,6 +229,7 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
                     opts.block_cache = leveldb::NewLRUCache(cache_sz);
                  }
         }
+#endif
         else if (option[0] == eleveldb::ATOM_COMPRESSION)
         {
             if (option[1] == eleveldb::ATOM_TRUE)

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -34,6 +34,7 @@
 
 #include "leveldb/db.h"
 #include "leveldb/comparator.h"
+#include "leveldb/env.h"
 #include "leveldb/write_batch.h"
 #include "leveldb/cache.h"
 #include "leveldb/filter_policy.h"
@@ -919,6 +920,8 @@ static void on_unload(ErlNifEnv *env, void *priv_data)
 {
     eleveldb_priv_data *p = static_cast<eleveldb_priv_data *>(priv_data);
     delete p;
+
+    leveldb::Env::Shutdown();
 }
 
 

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -139,7 +139,8 @@
 %% can alternately be assigned as a byte count via total_leveldb_mem instead.
 {mapping, "multi_backend.$name.leveldb.total_leveldb_mem_percent", "riak_kv.multi_backend", [
   {default, "45"},
-  {datatype, integer}
+  {datatype, integer},
+  {level, advanced}
 ]}.
 
 

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -1,0 +1,239 @@
+
+%%%% This is the leveldb section
+
+%% @doc leveldb data_root
+{mapping, "leveldb.data_root", "eleveldb.data_root", [
+  {default, "{{platform_data_dir}}/leveldb"}
+]}.
+
+
+%% @doc This parameter defines the percentage, 1 to 100, of total
+%% server memory to assign to leveldb.  leveldb will dynamically
+%% adjust it internal cache sizes as Riak activates / inactivates
+%% vnodes on this server to stay within this size.  The memory size
+%% can alternately be assigned as a byte count via total_leveldb_mem instead.
+{mapping, "leveldb.total_leveldb_mem_percent", "eleveldb.total_leveldb_mem_percent", [
+  {default, "90"},
+  {datatype, integer}
+]}.
+
+
+%% @doc This parameter defines the number of bytes of
+%% server memory to assign to leveldb.  leveldb will dynamically
+%% adjust it internal cache sizes as Riak activates / inactivates
+%% vnodes on this server to stay within this size.  The memory size
+%% can alternately be assigned as percentage of total server memory
+%% via total_leveldb_mem_percent instead.
+{mapping, "leveldb.total_leveldb_mem", "eleveldb.total_leveldb_mem", [
+  {default, "1GB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc The 'sync' parameter defines how new key/value data is placed in the
+%% recovery log. The recovery log is only used if the Riak program crashes or
+%% the server loses power unexpectedly. The parameter's original intent was
+%% to guarantee that each new key / value was written to the physical disk
+%% before leveldb responded with “write good”. The reality in modern servers
+%% is that many layers of data caching exist between the database program and
+%% the physical disks. This flag influences only one of the layers.
+{mapping, "leveldb.sync", "eleveldb.sync", [
+  {default, false},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+
+
+%% @doc Each vnode first stores new key/value data in a memory based write
+%% buffer. This write buffer is in parallel to the recovery log mentioned
+%% in the “sync” parameter. Riak creates each vnode with a randomly sized
+%% write buffer for performance reasons. The random size is somewhere
+%% between write_buffer_size_min and write_buffer_size_max.
+{mapping, "leveldb.write_buffer_size_min", "eleveldb.write_buffer_size_min", [
+  {default, "30MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+{mapping, "leveldb.write_buffer_size_max", "eleveldb.write_buffer_size_max", [
+  {default, "60MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc Each database .sst table file can include an optional "bloom filter"
+%% that is highly effective in shortcutting data queries that are destined
+%% to not find the requested key. The bloom_filter typically increases the
+%% size of an .sst table file by about 2%. This option must be set to true
+%% in the riak.conf to take effect.
+{mapping, "leveldb.bloomfilter", "eleveldb.use_bloomfilter", [
+  {default, on},
+  {datatype, {enum, [on, off]}}
+]}.
+
+{ translation,
+  "eleveldb.use_bloomfilter",
+  fun(Conf) ->
+    case cuttlefish_util:conf_get_value("leveldb.bloomfilter", Conf) of
+        on -> true;
+        off -> false;
+        _ -> true
+    end
+  end
+}.
+
+
+%% @doc sst_block_size defines the size threshold for a block / chunk of data
+%% within one .sst table file. Each new block gets an index entry in the .sst
+%% table file's master index.
+{mapping, "leveldb.block_size", "eleveldb.sst_block_size", [
+  {default, "4KB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc block_restart_interval defines the key count threshold for a new key
+%% entry in the key index for a block.
+%% Most clients should leave this parameter alone.
+{mapping, "leveldb.block_restart_interval", "eleveldb.block_restart_interval", [
+  {default, 16},
+  {datatype, integer},
+  {level, advanced}
+]}.
+
+
+%% @doc verify_checksums controls whether or not validation occurs when Riak
+%% requests data from the leveldb database on behalf of the user.
+{mapping, "leveldb.verify_checksums", "eleveldb.verify_checksums", [
+  {default, true},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+
+
+%% @doc verify_compaction controls whether or not validation occurs when
+%% leveldb reads data as part of its background compaction operations.
+{mapping, "leveldb.verify_compaction", "eleveldb.verify_compaction", [
+  {default, true},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+
+
+%%%% This is the multi-backend leveldb section
+
+%% @doc leveldb data_root
+{mapping, "multi_backend.$name.leveldb.data_root", "riak_kv.multi_backend", [
+  {default, "{{platform_data_dir}}/multleveldb"},
+  {level, advanced}
+]}.
+
+
+%% @doc This parameter defines the percentage, 1 to 100, of total
+%% server memory to assign to leveldb.  leveldb will dynamically
+%% adjust it internal cache sizes as Riak activates / inactivates
+%% vnodes on this server to stay within this size.  The memory size
+%% can alternately be assigned as a byte count via total_leveldb_mem instead.
+{mapping, "multi_backend.$name.leveldb.total_leveldb_mem_percent", "riak_kv.multi_backend", [
+  {default, "45"},
+  {datatype, integer}
+]}.
+
+
+%% @doc This parameter defines the number of bytes of
+%% server memory to assign to leveldb.  leveldb will dynamically
+%% adjust it internal cache sizes as Riak activates / inactivates
+%% vnodes on this server to stay within this size.  The memory size
+%% can alternately be assigned as percentage of total server memory
+%% via total_leveldb_mem_percent instead.
+{mapping, "multi_backend.$name.leveldb.total_leveldb_mem", "riak_kv.multi_backend", [
+  {default, "512MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc The 'sync' parameter defines how new key/value data is placed in the
+%% recovery log. The recovery log is only used if the Riak program crashes or
+%% the server loses power unexpectedly. The parameter's original intent was
+%% to guarantee that each new key / value was written to the physical disk
+%% before leveldb responded with “write good”. The reality in modern servers
+%% is that many layers of data caching exist between the database program and
+%% the physical disks. This flag influences only one of the layers.
+{mapping, "multi_backend.$name.leveldb.sync", "riak_kv.multi_backend", [
+  {default, false},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+
+
+%% @doc Each vnode first stores new key/value data in a memory based write
+%% buffer. This write buffer is in parallel to the recovery log mentioned
+%% in the “sync” parameter. Riak creates each vnode with a randomly sized
+%% write buffer for performance reasons. The random size is somewhere
+%% between write_buffer_size_min and write_buffer_size_max.
+{mapping, "multi_backend.$name.leveldb.write_buffer_size_min", "riak_kv.multi_backend", [
+  {default, "15MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+{mapping, "multi_backend.$name.leveldb.write_buffer_size_max", "riak_kv.multi_backend", [
+  {default, "30MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc Each database .sst table file can include an optional "bloom filter"
+%% that is highly effective in shortcutting data queries that are destined
+%% to not find the requested key. The bloom_filter typically increases the
+%% size of an .sst table file by about 2%. This option must be set to true
+%% in the riak.conf to take effect.
+{mapping, "multi_backend.$name.leveldb.bloomfilter", "riak_kv.multi_backend", [
+  {default, on},
+  {datatype, {enum, [on, off]}},
+  {level, advanced}
+]}.
+
+
+%% @doc sst_block_size defines the size threshold for a block / chunk of data
+%% within one .sst table file. Each new block gets an index entry in the .sst
+%% table file's master index.
+{mapping, "multi_backend.$name.leveldb.block_size", "riak_kv.multi_backend", [
+  {default, "4KB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc block_restart_interval defines the key count threshold for a new key
+%% entry in the key index for a block.
+%% Most clients should leave this parameter alone.
+{mapping, "multi_backend.$name.leveldb.block_restart_interval", "riak_kv.multi_backend", [
+  {default, 16},
+  {datatype, integer},
+  {level, advanced}
+]}.
+
+
+%% @doc verify_checksums controls whether or not validation occurs when Riak
+%% requests data from the leveldb database on behalf of the user.
+{mapping, "multi_backend.$name.leveldb.verify_checksums", "riak_kv.multi_backend", [
+  {default, true},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+
+
+%% @doc verify_compaction controls whether or not validation occurs when
+%% leveldb reads data as part of its background compaction operations.
+{mapping, "multi_backend.$name.leveldb.verify_compaction", "riak_kv.multi_backend", [
+  {default, true},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+

--- a/src/eleveldb.app.src
+++ b/src/eleveldb.app.src
@@ -8,10 +8,12 @@
                   stdlib
                  ]},
   {env, [
-         %% Max file handles to keep open by default
-         %% NOTE: 20 is the lowest value permitted by LevelDB; if you set it lower
-         %%       than this, LevelDB will bump override it up to 20
-         {max_open_files, 20},
+         %% what percent of total memory should go to 
+         %%  leveldb.  Default is 15% on the basis of
+         %%  a single development machine running 5 
+         %%  Riak instances would therefore claim 75%.
+         %% REAL users will want this at 75 to 80
+         {total_leveldb_mem_percent, 15},
 
          %% Use bloom filter support by default
          {use_bloomfilter, true}

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -96,7 +96,8 @@ init() ->
                          {compression, boolean()} |
                          {use_bloomfilter, boolean() | pos_integer()} |
                          {write_threads, pos_integer()} |
-                         {total_leveldb_mem, pos_integer()}].
+                         {total_leveldb_mem, pos_integer()} |
+                         {is_internal_db, boolean()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
                          {fill_cache, boolean()}].
@@ -271,7 +272,8 @@ option_types(open) ->
      {compression, bool},
      {use_bloomfilter, any},
      {write_threads, integer},
-     {total_leveldb_mem, integer}];
+     {total_leveldb_mem, integer},
+     {is_internal_db, bool}];
 option_types(read) ->
     [{verify_checksums, bool},
      {fill_cache, bool}];

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -95,7 +95,8 @@ init() ->
                          {verify_compactions, boolean()} |
                          {compression, boolean()} |
                          {use_bloomfilter, boolean() | pos_integer()} |
-                         {write_threads, pos_integer()}].
+                         {write_threads, pos_integer()} |
+                         {total_leveldb_mem, pos_integer()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
                          {fill_cache, boolean()}].
@@ -269,7 +270,8 @@ option_types(open) ->
      {verify_compactions, bool},
      {compression, bool},
      {use_bloomfilter, any},
-     {write_threads, integer}];
+     {write_threads, integer},
+     {total_leveldb_mem, integer}];
 option_types(read) ->
     [{verify_checksums, bool},
      {fill_cache, bool}];

--- a/test/cacheleak.erl
+++ b/test/cacheleak.erl
@@ -30,7 +30,7 @@ cacheleak_test_() ->
                               [] = os:cmd("rm -rf /tmp/eleveldb.cacheleak.test"),
                               Blobs = [{<<I:128/unsigned>>, compressible_bytes(10240)} ||
                                           I <- lists:seq(1, 10000)],
-                              cacheleak_loop(10, Blobs, 400000)
+                              cacheleak_loop(10, Blobs, 500000)
                       end}.
 
 %% It's very important for this test that the data is compressible. Otherwise,

--- a/test/cacheleak.erl
+++ b/test/cacheleak.erl
@@ -30,7 +30,7 @@ cacheleak_test_() ->
                               [] = os:cmd("rm -rf /tmp/eleveldb.cacheleak.test"),
                               Blobs = [{<<I:128/unsigned>>, compressible_bytes(10240)} ||
                                           I <- lists:seq(1, 10000)],
-                              cacheleak_loop(10, Blobs, 350000)
+                              cacheleak_loop(10, Blobs, 400000)
                       end}.
 
 %% It's very important for this test that the data is compressible. Otherwise,


### PR DESCRIPTION
This is the eleveldb side of mv-flexcache branch (already reviewed) in basho/leveldb.  The branch creates 3 config atoms:  total_memory, total_leveldb_mem, and total_leveldb_mem_percent.  Engel wrote code for total_memory.  The value is populated upon each database open for potential use with total_leveldb_mem_percent.  Any configuration value supplied by the user for total_leveldb_mem or total_leveldb_mem_percent is placed in the leveldb::Options.total_leveldb_mem structure member.  If between 0 and 100, it is assumed later to be a percent and applied against total_memory to achieve a byte value.
