### PR TITLE
add limited_developer_mem option flag (support)

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="mv-flexcache2"
+LEVELDB_VSN="0e6a55f51427349815c7e741a5e02f8b4e2b5a30"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="b4f590fd44e865ef6fac0c7886ea324c3534b846"
+LEVELDB_VSN="mv-flexcache2"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -121,6 +121,7 @@ ERL_NIF_TERM ATOM_TOTAL_MEMORY;
 ERL_NIF_TERM ATOM_TOTAL_LEVELDB_MEM;
 ERL_NIF_TERM ATOM_TOTAL_LEVELDB_MEM_PERCENT;
 ERL_NIF_TERM ATOM_IS_INTERNAL_DB;
+ERL_NIF_TERM ATOM_LIMITED_DEVELOPER_MEM;
 
 }   // namespace eleveldb
 
@@ -278,6 +279,13 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
                 opts.is_internal_db = true;
             else
                 opts.is_internal_db = false;
+        }
+        else if (option[0] == eleveldb::ATOM_LIMITED_DEVELOPER_MEM)
+        {
+            if (option[1] == eleveldb::ATOM_TRUE)
+                opts.limited_developer_mem = true;
+            else
+                opts.limited_developer_mem = false;
         }
     }
 
@@ -1050,6 +1058,7 @@ try
     ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_leveldb_mem");
     ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM_PERCENT, "total_leveldb_mem_percent");
     ATOM(eleveldb::ATOM_IS_INTERNAL_DB, "is_internal_db");
+    ATOM(eleveldb::ATOM_LIMITED_DEVELOPER_MEM, "limited_developer_mem");
 
 #undef ATOM
 

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -44,6 +44,17 @@
   {level, advanced}
 ]}.
 
+%% @doc limited_developer_mem is a Riak specific option that is used when
+%% a developer is testing a high number of vnodes and/or several VMs
+%% on a machine with limited physical memory.  Do NOT use this option
+%% if making performance measurements.  This option overwrites values
+%% given to write_buffer_size_min and write_buffer_size_max.
+{mapping, "leveldb.limited_developer_mem", "eleveldb.limited_developer_mem", [
+  {default, false},
+  {datatype, {enum, [true, false]}},
+  {level, advanced}
+]}.
+
 
 %% @doc Each vnode first stores new key/value data in a memory based write
 %% buffer. This write buffer is in parallel to the recovery log mentioned
@@ -153,6 +164,18 @@
 {mapping, "multi_backend.$name.leveldb.total_leveldb_mem", "riak_kv.multi_backend", [
   {default, "512MB"},
   {datatype, bytesize},
+  {level, advanced}
+]}.
+
+
+%% @doc limited_developer_mem is a Riak specific option that is used when
+%% a developer is testing a high number of vnodes and/or several VMs
+%% on a machine with limited physical memory.  Do NOT use this option
+%% if making performance measurements.  This option overwrites values
+%% given to write_buffer_size_min and write_buffer_size_max.
+{mapping, "multi_backend.$name.leveldb.limited_developer_mem", "riak_kv.multi_backend", [
+  {default, false},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -97,7 +97,8 @@ init() ->
                          {total_memory, pos_integer()} |
                          {total_leveldb_mem, pos_integer()} |
                          {total_leveldb_mem_percent, pos_integer()} |
-                         {is_internal_db, boolean()}].
+                         {is_internal_db, boolean()} |
+                         {limited_developer_mem, boolean()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
                          {fill_cache, boolean()}].
@@ -274,7 +275,8 @@ option_types(open) ->
      {total_memory, integer},
      {total_leveldb_mem, integer},
      {total_leveldb_mem_percent, integer},
-     {is_internal_db, bool}];
+     {is_internal_db, bool},
+     {limited_developer_mem, bool}];
 option_types(read) ->
     [{verify_checksums, bool},
      {fill_cache, bool}];


### PR DESCRIPTION
Add support for setting "limited_developer_mem" option of leveldb.
