### PR TITLE
add support for OS X Mavericks

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="4b5245ad33301a8b50e5f4f29f272dca1ff4cce2"
+LEVELDB_VSN="967801e8c09cc29804972d4373a36cf659bb63b1"
 
 SNAPPY_VSN="1.0.4"
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+%%-*- mode: erlang -*-
 {eunit_opts, [verbose]}.
 {so_name, "eleveldb.so"}.
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,31 @@
+%%-*- mode: erlang -*-
+
+%% Set the minimum Mac target to 10.8 for 10.9 or greater.  This runtime
+%% check is needed since rebar's system_architecture check looks only at
+%% the version of the OS used to build the Erlang runtime, not the version
+%% actually running.
+case os:type() of
+    {unix,darwin} ->
+        Opt = " -mmacosx-version-min=10.8",
+        [Mjr|_] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
+        Major = list_to_integer(Mjr),
+        if
+            Major >= 13 ->
+                Flags = ["CFLAGS", "CXXFLAGS", "DRV_CFLAGS", "DRV_LDFLAGS"],
+                {port_env, Vals} = lists:keyfind(port_env, 1, CONFIG),
+                Fold = fun({Flag,Val}, Acc) ->
+                               case lists:member(Flag, Flags) of
+                                   true ->
+                                      [{Flag, Val++Opt}|Acc];
+                                   false ->
+                                       Acc
+                               end
+                       end,
+                NewVals = lists:foldl(Fold, [], Vals),
+                lists:keyreplace(port_env, 1, CONFIG, {port_env, NewVals});
+            true ->
+                CONFIG
+        end;
+    _ ->
+        CONFIG
+end.


### PR DESCRIPTION
Enable eleveldb to run on OS X Mavericks. Pick up a new leveldb commit, and
add new Mavericks-specific switches to rebar.config.

Tested successfully on Mavericks, Mountain Lion, and Lion.

Requires leveldb changes too, see https://github.com/basho/leveldb/pull/104 .
