### PR TITLE
fixed dialyzer errors in async_iterator_move

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -180,10 +180,11 @@ iterator(Ref, Opts, keys_only) ->
     async_iterator(CallerRef, Ref, Opts, keys_only),
     ?WAIT_FOR_REPLY(CallerRef).
 
--spec async_iterator_move(reference(), itr_ref(), iterator_action()) -> {reference(), {ok, Key::binary(), Value::binary()}} |
-                                                                        {reference(), {ok, Key::binary()}} |
-                                                                        {reference(), {error, invalid_iterator}} |
-                                                                        {reference(), {error, iterator_closed}}.
+-spec async_iterator_move(reference()|undefined, itr_ref(), iterator_action()) -> reference() |
+                                                                        {ok, Key::binary(), Value::binary()} |
+                                                                        {ok, Key::binary()} |
+                                                                        {error, invalid_iterator} |
+                                                                        {error, iterator_closed}.
 async_iterator_move(_CallerRef, _IterRef, _IterAction) ->
     erlang:nif_error({error, not_loaded}).
 


### PR DESCRIPTION
Hi I fixed two problems with the specs of async_iterator_move. That said please double check of this new specs are correct, they make sense from the way the functions is called and from looking at the C-Code it also seems to be the proper return but I'm not that deep into the levedb C-code that I feel 100% confident about reading it correctly.
