### PR TITLE
Batch iterators - improved performance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ c_src/system
 *~
 .project
 .settings
+/eleveldb_c/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ c_src/leveldb/
 c_src/snappy*/
 c_src/system
 *~
+.project
+.settings

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -718,6 +718,9 @@ async_iterator_move(
         submit_new_request=true;
         ret_term = enif_make_copy(env, itr_ptr->m_Snapshot->itr_ref);
 
+        //turn off prefetch
+        itr_ptr->m_Iter->m_PrefetchStarted=false;
+
         // force reply to be a message
         itr_ptr->m_Iter->m_HandoffAtomic=1;
     }   // if

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -766,8 +766,8 @@ async_iterator_move(
             ret_term=enif_make_tuple2(env, ATOM_ERROR, ATOM_INVALID_ITERATOR);
         }
         else {
-        	assert(itr_ptr->m_Iter->m_CurrentData != 0);
-        	ret_term = enif_make_tuple2(env, ATOM_OK, itr_ptr->m_Iter->m_CurrentData);
+        	ret_term = enif_make_tuple2(env, ATOM_OK, enif_make_copy(env, itr_ptr->m_Iter->m_CurrentData));
+        	itr_ptr->m_Iter->m_CurrentData = 0;
         }
 
         // reset for next race

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -677,10 +677,11 @@ async_iterator_move(
     // const ERL_NIF_TERM& caller_ref       = argv[0];
     const ERL_NIF_TERM& itr_handle_ref   = argv[1];
     const ERL_NIF_TERM& action_or_target = argv[2];
-    const ERL_NIF_TERM& erl_batch_size       = argv[3];
+    const ERL_NIF_TERM& erl_batch_size   = argv[3];
     int batch_size;
-    if (!enif_get_int(env, erl_batch_size, &batch_size)) {
-    	batch_size = 1;
+    if (!enif_get_int(env, erl_batch_size, &batch_size))
+    {
+        batch_size = 1;
     }
     ERL_NIF_TERM ret_term;
 
@@ -762,12 +763,14 @@ async_iterator_move(
     {
         // why yes there is.  copy the key/value info into a return tuple before
         //  we launch the iterator for "next" again
-        if(!itr_ptr->m_Iter->Valid()) {
+        if(!itr_ptr->m_Iter->Valid())
+        {
             ret_term=enif_make_tuple2(env, ATOM_ERROR, ATOM_INVALID_ITERATOR);
         }
-        else {
-        	ret_term = enif_make_tuple2(env, ATOM_OK, enif_make_copy(env, itr_ptr->m_Iter->m_CurrentData));
-        	itr_ptr->m_Iter->m_CurrentData = 0;
+        else
+        {
+            ret_term = enif_make_tuple2(env, ATOM_OK, enif_make_copy(env, itr_ptr->m_Iter->m_CurrentData));
+            itr_ptr->m_Iter->m_CurrentData = 0;
         }
 
         // reset for next race

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -769,13 +769,6 @@ async_iterator_move(
         	assert(itr_ptr->m_Iter->m_CurrentData != 0);
         	ret_term = enif_make_tuple2(env, ATOM_OK, itr_ptr->m_Iter->m_CurrentData);
         }
-        /*else if (itr_ptr->m_Iter->m_KeysOnly)
-            ret_term=enif_make_tuple2(env, ATOM_OK, slice_to_binary(env, itr_ptr->m_Iter->key()));
-        else
-            ret_term=enif_make_tuple3(env, ATOM_OK,
-                                      slice_to_binary(env, itr_ptr->m_Iter->key()),
-                                      slice_to_binary(env, itr_ptr->m_Iter->value()));*/
-
 
         // reset for next race
         itr_ptr->m_Iter->m_HandoffAtomic=0;

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -151,16 +151,6 @@ static ERL_NIF_TERM error_tuple(ErlNifEnv* env, ERL_NIF_TERM error, leveldb::Sta
                             enif_make_tuple2(env, error, reason));
 }
 
-/*
-static ERL_NIF_TERM slice_to_binary(ErlNifEnv* env, leveldb::Slice s)
-{
-    ERL_NIF_TERM result;
-    unsigned char* value = enif_make_new_binary(env, s.size(), &result);
-    memcpy(value, s.data(), s.size());
-    return result;
-}
-*/
-
 /** struct for grabbing eleveldb environment options via fold
  *   ... then loading said options into eleveldb_priv_data
  */

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -540,6 +540,17 @@ ItrObject::ReleaseReuseMove()
 }   // ItrObject::ReleaseReuseMove()
 
 
+bool LevelIteratorWrapper::acquire()
+{
+    return compare_and_swap(&m_ItrBusy, false, true);
+}
+
+void LevelIteratorWrapper::release()
+{
+    m_ItrBusy = false;
+}
+
+
 } // namespace eleveldb
 
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -275,11 +275,13 @@ public:
     bool m_KeysOnly;                          //!< only return key values
     bool m_PrefetchStarted;                   //!< true after first prefetch command
     ERL_NIF_TERM m_CurrentData;               //!< list of KV or Keys gained from iterator after last (batch or not) move
+    volatile bool m_ItrBusy;                  //!< flags that iterator is acuired by smb and cannot be used right now
 
     LevelIteratorWrapper(DbObject * DbPtr, LevelSnapshotWrapper * Snapshot,
                          leveldb::Iterator * Iterator, bool KeysOnly)
         : m_DbPtr(DbPtr), m_Snap(Snapshot), m_Iterator(Iterator),
-        m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false), m_CurrentData(0)
+        m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false), 
+        m_CurrentData(0), m_ItrBusy(false)
     {
     };
 
@@ -298,6 +300,9 @@ public:
     bool Valid() {return(m_CurrentData != 0);};
     leveldb::Slice key() {return(m_Iterator->key());};
     leveldb::Slice value() {return(m_Iterator->value());};
+    
+    bool acquire();
+    void release();
 
 private:
     LevelIteratorWrapper(const LevelIteratorWrapper &);            // no copy

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -279,7 +279,7 @@ public:
     LevelIteratorWrapper(DbObject * DbPtr, LevelSnapshotWrapper * Snapshot,
                          leveldb::Iterator * Iterator, bool KeysOnly)
         : m_DbPtr(DbPtr), m_Snap(Snapshot), m_Iterator(Iterator),
-        m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false)
+        m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false), m_CurrentData(0)
     {
     };
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -274,7 +274,7 @@ public:
     volatile uint32_t m_HandoffAtomic;        //!< matthew's atomic foreground/background prefetch flag.
     bool m_KeysOnly;                          //!< only return key values
     bool m_PrefetchStarted;                   //!< true after first prefetch command
-    ERL_NIF_TERM m_CurrentData;
+    ERL_NIF_TERM m_CurrentData;               //!< list of KV or Keys gained from iterator after last (batch or not) move
 
     LevelIteratorWrapper(DbObject * DbPtr, LevelSnapshotWrapper * Snapshot,
                          leveldb::Iterator * Iterator, bool KeysOnly)

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -274,6 +274,7 @@ public:
     volatile uint32_t m_HandoffAtomic;        //!< matthew's atomic foreground/background prefetch flag.
     bool m_KeysOnly;                          //!< only return key values
     bool m_PrefetchStarted;                   //!< true after first prefetch command
+    ERL_NIF_TERM m_CurrentData;
 
     LevelIteratorWrapper(DbObject * DbPtr, LevelSnapshotWrapper * Snapshot,
                          leveldb::Iterator * Iterator, bool KeysOnly)
@@ -294,7 +295,7 @@ public:
     leveldb::Iterator * get() {return(m_Iterator);};
     leveldb::Iterator * operator->() {return(m_Iterator);};
 
-    bool Valid() {return(m_Iterator->Valid());};
+    bool Valid() {return(m_CurrentData != 0);};
     leveldb::Slice key() {return(m_Iterator->key());};
     leveldb::Slice value() {return(m_Iterator->value());};
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -297,9 +297,16 @@ ERL_NIF_TERM MoveTask::extract(leveldb::Iterator* itr, const bool keys_only)
 
 void MoveTask::read_single(leveldb::Iterator* itr)
 {
-    assert(itr->Valid());
-    const bool keys_only = m_ItrWrap->m_KeysOnly;
-    m_ItrWrap->m_CurrentData = enif_make_list1(local_env(), extract(itr, keys_only));
+    if(itr->Valid())
+    {
+        const bool keys_only = m_ItrWrap->m_KeysOnly;
+        m_ItrWrap->m_CurrentData = enif_make_list1(local_env(), extract(itr, keys_only));
+    }
+    else
+    {
+        m_ItrWrap->m_CurrentData = 0;
+    }
+
 }
 
 void MoveTask::apply_action(leveldb::Iterator* itr)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -243,7 +243,7 @@ MoveTask::operator()()
         }   // if
         else
         {
-        	assert(m_ItrWrap->m_CurrentData == 0);
+            assert(m_ItrWrap->m_CurrentData == 0);
             return work_result(local_env(), ATOM_ERROR, ATOM_INVALID_ITERATOR);
         }   // else
 
@@ -348,7 +348,7 @@ MoveTask::recycle()
     {
         if (NULL!=local_env_)
         {
-        	assert(m_ItrWrap->m_CurrentData == 0);
+            assert(m_ItrWrap->m_CurrentData == 0);
             enif_clear_env(local_env_);
         }
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -237,9 +237,9 @@ MoveTask::operator()()
                 prepare_recycle();
 
             // erlang is waiting, send message
-			work_result r(local_env(), ATOM_OK, m_ItrWrap->m_CurrentData);
-			m_ItrWrap->m_CurrentData = 0;
-			return r;
+            work_result r(local_env(), ATOM_OK, m_ItrWrap->m_CurrentData);
+            m_ItrWrap->m_CurrentData = 0;
+            return r;
         }   // if
         else
         {
@@ -254,57 +254,62 @@ MoveTask::operator()()
 
 void MoveTask::read_batch(leveldb::Iterator* itr)
 {
-	const bool keys_only = m_ItrWrap->m_KeysOnly;
-	std::vector<ERL_NIF_TERM> list;
-	list.reserve(batch_size);
-	for (int k = 0; k < batch_size && itr->Valid(); ++k) {
+    const bool keys_only = m_ItrWrap->m_KeysOnly;
+    std::vector<ERL_NIF_TERM> list;
+    list.reserve(batch_size);
+    for (int k = 0; k < batch_size && itr->Valid(); ++k) {
 
-		apply_action(itr);
-		if (!itr->Valid()) {
-			break;
-		}
-		list.push_back(extract(itr, keys_only));
-	}
-	if (list.size() != 0) {
-		assert(m_ItrWrap->m_CurrentData == 0);
-		m_ItrWrap->m_CurrentData = enif_make_list_from_array(local_env(), &list[0], list.size());
-	}
-	else {
-		assert(m_ItrWrap->m_CurrentData == 0);
-		//m_ItrWrap->m_CurrentData = 0;
-	}
+        apply_action(itr);
+        if (!itr->Valid())
+        {
+            break;
+        }
+        list.push_back(extract(itr, keys_only));
+    }
+    if (list.size() != 0)
+    {
+        assert(m_ItrWrap->m_CurrentData == 0);
+        m_ItrWrap->m_CurrentData = enif_make_list_from_array(local_env(), &list[0], list.size());
+    }
+    else
+    {
+        assert(m_ItrWrap->m_CurrentData == 0);
+        //m_ItrWrap->m_CurrentData = 0;
+    }
 }
 
 ERL_NIF_TERM MoveTask::extract(leveldb::Iterator* itr, const bool keys_only)
 {
-	assert(itr->Valid());
-	ERL_NIF_TERM elem;
-	if(keys_only) {
-		elem = slice_to_binary(local_env(), itr->key());
-	}
-	else {
-		elem = enif_make_tuple2(local_env(),
-						slice_to_binary(local_env(), itr->key()),
-						slice_to_binary(local_env(), itr->value()));
-	}
-	return elem;
+    assert(itr->Valid());
+    ERL_NIF_TERM elem;
+    if(keys_only)
+    {
+        elem = slice_to_binary(local_env(), itr->key());
+    }
+    else
+    {
+        elem = enif_make_tuple2(local_env(),
+                slice_to_binary(local_env(), itr->key()),
+                slice_to_binary(local_env(), itr->value()));
+    }
+    return elem;
 }
 
 void MoveTask::read_single(leveldb::Iterator* itr)
 {
-	assert(itr->Valid());
-	const bool keys_only = m_ItrWrap->m_KeysOnly;
-	m_ItrWrap->m_CurrentData = enif_make_list1(local_env(), extract(itr, keys_only));
+    assert(itr->Valid());
+    const bool keys_only = m_ItrWrap->m_KeysOnly;
+    m_ItrWrap->m_CurrentData = enif_make_list1(local_env(), extract(itr, keys_only));
 }
 
 void MoveTask::apply_action(leveldb::Iterator* itr)
 {
-	switch (action) {
-	case PREFETCH:
-	case NEXT:  itr->Next(); break;
-	case PREV:  itr->Prev(); break;
-	default: break;
-	}
+    switch (action) {
+    case PREFETCH:
+    case NEXT:  itr->Next(); break;
+    case PREV:  itr->Prev(); break;
+    default: break;
+    }
 }
 
 
@@ -341,7 +346,8 @@ MoveTask::recycle()
     // test for race condition of simultaneous delete & recycle
     if (1<RefInc())
     {
-        if (NULL!=local_env_) {
+        if (NULL!=local_env_)
+        {
         	assert(m_ItrWrap->m_CurrentData == 0);
             enif_clear_env(local_env_);
         }

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -317,6 +317,7 @@ public:
     action_t                                    action;
     int                                         batch_size;
     std::string                                 seek_target;
+    bool                                        owns_iterator;
 
 public:
 
@@ -324,7 +325,7 @@ public:
     MoveTask(ErlNifEnv *_caller_env, ERL_NIF_TERM _caller_ref,
              LevelIteratorWrapper * IterWrap, action_t& _action, int _batch_size)
         : WorkTask(NULL, _caller_ref),
-        m_ItrWrap(IterWrap), action(_action), batch_size(_batch_size)
+        m_ItrWrap(IterWrap), action(_action), batch_size(_batch_size), owns_iterator(false)
     {
         // special case construction
         local_env_=NULL;
@@ -337,7 +338,8 @@ public:
              std::string& _seek_target)
         : WorkTask(NULL, _caller_ref),
         m_ItrWrap(IterWrap), action(_action),
-        seek_target(_seek_target)
+        seek_target(_seek_target),
+        owns_iterator(false)
         {
             // special case construction
             local_env_=NULL;

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -314,16 +314,17 @@ protected:
     ReferencePtr<LevelIteratorWrapper> m_ItrWrap;             //!< access to database, and holds reference
 
 public:
-    action_t                                       action;
+    action_t                                    action;
+    int											batch_size;
     std::string                                 seek_target;
 
 public:
 
     // No seek target:
     MoveTask(ErlNifEnv *_caller_env, ERL_NIF_TERM _caller_ref,
-             LevelIteratorWrapper * IterWrap, action_t& _action)
+             LevelIteratorWrapper * IterWrap, action_t& _action, int _batch_size)
         : WorkTask(NULL, _caller_ref),
-        m_ItrWrap(IterWrap), action(_action)
+        m_ItrWrap(IterWrap), action(_action), batch_size(_batch_size)
     {
         // special case construction
         local_env_=NULL;
@@ -350,6 +351,12 @@ public:
 
     virtual void prepare_recycle();
     virtual void recycle();
+
+private:
+    void read_batch(leveldb::Iterator* itr);
+    void read_single(leveldb::Iterator* itr);
+    ERL_NIF_TERM extract(leveldb::Iterator* itr, bool keys_only);
+    void apply_action(leveldb::Iterator* itr);
 
 };  // class MoveTask
 

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -315,7 +315,7 @@ protected:
 
 public:
     action_t                                    action;
-    int											batch_size;
+    int                                         batch_size;
     std::string                                 seek_target;
 
 public:

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -357,13 +357,8 @@ fold_loop({error, invalid_iterator}, _Itr, _Fun, Acc0, _) ->
     Acc0;
 
 fold_loop({ok, KVList}, Itr, Fun, Acc0, BatchSize) when is_list(KVList)->
-    Ref = async_iterator_move(undefined, Itr, next, BatchSize),
     Acc = lists:foldl(Fun, Acc0, KVList),
-    NextBatch = receive 
-                    {Ref, X} ->
-                        X
-                end,
-    fold_loop(NextBatch, Itr, Fun, Acc, BatchSize).
+    fold_loop(iterator_move(Itr, prefetch, BatchSize), Itr, Fun, Acc, BatchSize).
 
 validate_type({_Key, bool}, true)                            -> true;
 validate_type({_Key, bool}, false)                           -> true;

--- a/test/fold_test.erl
+++ b/test/fold_test.erl
@@ -3,13 +3,13 @@
 %% Description: TODO: Add description to fold_test
 -module(fold_test).
 
--export([create_db/1, calc_crc32/3, calc_func/2]).
+-export([create_db/1, calc_crc32/3, calc_count/3, calc_crc_func/2, calc_count_func/2]).
 
 create_db(Path) ->
     {ok, Ref} = eleveldb:open(Path,  [{create_if_missing, true}]),
     try
         R = [
-         eleveldb:put(Ref, <<X:64/integer, Y:32/integer>>, <<Y:32/integer, X:64/integer>>, []) || X <- lists:seq(1, 10000), Y <- lists:seq(1, 100)
+         eleveldb:put(Ref, <<X:64/integer, Y:32/integer>>, <<Y:32/integer, X:64/integer>>, []) || X <- lists:seq(1, 10000), Y <- lists:seq(1, 1000)
          ],
     lists:all(fun(X)->X =:= ok end, R)
     after
@@ -20,14 +20,36 @@ calc_crc32(DbPath, BatchSize, Reference) ->
     {ok, Ref} = eleveldb:open(DbPath,  [{create_if_missing, false}]),
     try
         Start = erlang:now(),
-        R = eleveldb:fold(Ref, fun calc_func/2, 0, [], BatchSize),
+        R = try
+                eleveldb:fold(Ref, fun calc_crc_func/2, 0, [], BatchSize)
+            catch
+                error:_ -> eleveldb:fold(Ref, fun calc_crc_func/2, 0, [])
+            end,
         End = erlang:now(),
         {{crc, R}, {time_msec, timer:now_diff(End, Start) / 1000}, {coinside, Reference =:= R} }
     after 
         eleveldb:close(Ref)
     end.
 
-calc_func({K, V}, Acc) -> 
+calc_crc_func({K, V}, Acc) -> 
     R = erlang:crc32(Acc, K),
     erlang:crc32(R, V).
+
+calc_count(DbPath, BatchSize, Reference) ->
+    {ok, Ref} = eleveldb:open(DbPath,  [{create_if_missing, false}]),
+    try
+        Start = erlang:now(),
+        R = try
+                eleveldb:fold(Ref, fun calc_count_func/2, 0, [], BatchSize)
+            catch
+                error:_ -> eleveldb:fold(Ref, fun calc_count_func/2, 0, [])
+            end,
+        End = erlang:now(),
+        {{count, R}, {time_msec, timer:now_diff(End, Start) / 1000}, {coinside, Reference =:= R} }
+    after 
+        eleveldb:close(Ref)
+    end.
+
+calc_count_func(_, Acc) ->
+    Acc + 1.
     

--- a/test/fold_test.erl
+++ b/test/fold_test.erl
@@ -1,0 +1,33 @@
+%% Author: sidorov
+%% Created: Nov 11, 2013
+%% Description: TODO: Add description to fold_test
+-module(fold_test).
+
+-export([create_db/1, calc_crc32/3, calc_func/2]).
+
+create_db(Path) ->
+    {ok, Ref} = eleveldb:open(Path,  [{create_if_missing, true}]),
+    try
+        R = [
+         eleveldb:put(Ref, <<X:64/integer, Y:32/integer>>, <<Y:32/integer, X:64/integer>>, []) || X <- lists:seq(1, 10000), Y <- lists:seq(1, 100)
+         ],
+    lists:all(fun(X)->X =:= ok end, R)
+    after
+        eleveldb:close(Ref)
+    end.
+
+calc_crc32(DbPath, BatchSize, Reference) ->
+    {ok, Ref} = eleveldb:open(DbPath,  [{create_if_missing, false}]),
+    try
+        Start = erlang:now(),
+        R = eleveldb:fold(Ref, fun calc_func/2, 0, [], BatchSize),
+        End = erlang:now(),
+        {{crc, R}, {time_msec, timer:now_diff(End, Start) / 1000}, {coinside, Reference =:= R} }
+    after 
+        eleveldb:close(Ref)
+    end.
+
+calc_func({K, V}, Acc) -> 
+    R = erlang:crc32(Acc, K),
+    erlang:crc32(R, V).
+    

--- a/test/iterators.erl
+++ b/test/iterators.erl
@@ -32,39 +32,26 @@ prev_test() ->
       eleveldb:put(Ref, <<"a">>, <<"x">>, []),
       eleveldb:put(Ref, <<"b">>, <<"y">>, []),
       {ok, I} = eleveldb:iterator(Ref, []),
-      io:format("got iter~n"),
         ?assertEqual({ok, [{<<"a">>, <<"x">>}]},eleveldb:iterator_move(I, <<>> , 1)),
-        io:format("1~n"),
         ?assertEqual({ok, [{<<"b">>, <<"y">>}]},eleveldb:iterator_move(I, next, 1)),
-      io:format("2~n"),
         ?assertEqual({ok, [{<<"a">>, <<"x">>}]},eleveldb:iterator_move(I, prev, 1)),
-      io:format("3~n"),
       
       eleveldb:put(Ref, <<"c">>, <<"z">>, []),
       {ok, I2} = eleveldb:iterator(Ref, []),
-      io:format("4~n"),
         ?assertEqual({ok, [{<<"a">>, <<"x">>}]},eleveldb:iterator_move(I2, <<>> , 1)),
-      io:format("5~n"),
         ?assertEqual({ok, [{<<"b">>, <<"y">>}, {<<"c">>, <<"z">>}]}, eleveldb:iterator_move(I2, next, 2)),
       
       {ok, I3} = eleveldb:iterator(Ref, []),
-      io:format("6~n"),
         ?assertEqual({ok, [{<<"a">>, <<"x">>}]},eleveldb:iterator_move(I3, <<>> , 1)),
-      io:format("7~n"),
         ?assertEqual({ok, [{<<"b">>, <<"y">>}]}, eleveldb:iterator_move(I3, prefetch, 1)),
         ?assertEqual({ok, [{<<"c">>, <<"z">>}]}, eleveldb:iterator_move(I3, prefetch, 1)),
       
       {ok, I4} = eleveldb:iterator(Ref, []),
-      io:format("8~n"),
         ?assertEqual({ok, [{<<"a">>, <<"x">>}]},eleveldb:iterator_move(I4, <<>> , 10)),
-      io:format("9~n"),
         ?assertEqual({ok, [{<<"b">>, <<"y">>}, {<<"c">>, <<"z">>}]}, eleveldb:iterator_move(I4, prefetch, 20)),
-      io:format("9~n"),
         ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I4, prefetch, 2)),
       
-      io:format("10~n"),
       ?assertEqual([<<"cz">>, <<"by">>, <<"ax">>], eleveldb:fold(Ref, fun({K,V}, Acc) -> [<<K/binary, V/binary>>|Acc] end, [], [], 2)),
-      io:format("11~n"),
       ?assertEqual([<<"cz">>, <<"by">>, <<"ax">>], eleveldb:fold(Ref, fun({K,V}, Acc) -> [<<K/binary, V/binary>>|Acc] end, [], [], 20))
     after
       eleveldb:close(Ref)


### PR DESCRIPTION
Grouping iterator movement operations allows to improve performance, so 'fold' runs ~10 times faster on my machine, than on original eleveldb when using batch_size ~1000 .
