### PR TITLE
Mv iterator refresh

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="mv-fadvise-control-2.0"
+LEVELDB_VSN="mv-iterator-refresh"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -769,14 +769,13 @@ async_iterator_move(
         ret_term = enif_make_copy(env, itr_ptr->itr_ref);
 
         // force reply to be a message
-        if (NULL!=itr_ptr->m_Iter.get())
-            itr_ptr->m_Iter->m_HandoffAtomic=1;
+        itr_ptr->m_Iter->m_HandoffAtomic=1;
     }   // if
 
     // case #2
     // before we launch a background job for "next iteration", see if there is a
     //  prefetch waiting for us
-    else if (NULL!=itr_ptr->m_Iter.get() && eleveldb::compare_and_swap(&itr_ptr->m_Iter->m_HandoffAtomic, 0, 1))
+    else if (eleveldb::compare_and_swap(&itr_ptr->m_Iter->m_HandoffAtomic, 0, 1))
     {
         // nope, no prefetch ... await a message to erlang queue
         ret_term = enif_make_copy(env, itr_ptr->itr_ref);
@@ -804,7 +803,7 @@ async_iterator_move(
     {
         // why yes there is.  copy the key/value info into a return tuple before
         //  we launch the iterator for "next" again
-        if(NULL==itr_ptr->m_Iter.get() || !itr_ptr->m_Iter->Valid())
+        if(!itr_ptr->m_Iter->Valid())
             ret_term=enif_make_tuple2(env, ATOM_ERROR, ATOM_INVALID_ITERATOR);
 
         else if (itr_ptr->m_Iter->m_KeysOnly)
@@ -815,8 +814,7 @@ async_iterator_move(
                                       slice_to_binary(env, itr_ptr->m_Iter->value()));
 
         // reset for next race
-        if (NULL!=itr_ptr->m_Iter.get())
-            itr_ptr->m_Iter->m_HandoffAtomic=0;
+        itr_ptr->m_Iter->m_HandoffAtomic=0;
 
         // old MoveItem could still be active on its thread, cannot
         //  reuse ... but the current Iterator is good

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -697,7 +697,6 @@ async_iterator(
     leveldb::ReadOptions *opts = new leveldb::ReadOptions;
     fold(env, options_ref, parse_read_option, *opts);
 
-    opts->iterator_refresh=true;
     eleveldb::WorkTask *work_item = new eleveldb::IterTask(env, caller_ref,
                                                            db_ptr.get(), keys_only, opts);
 

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -496,6 +496,9 @@ ItrObject::~ItrObject()
 
     delete m_ReadOptions;
 
+    if (NULL!=itr_ref_env)
+        enif_free_env(itr_ref_env);
+
     if (NULL!=m_DbPtr.get())
         m_DbPtr->RemoveReference(this);
 

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -321,7 +321,6 @@ DbObject::~DbObject()
 void
 DbObject::Shutdown()
 {
-#if 1
     bool again;
     ItrObject * itr_ptr;
 
@@ -348,7 +347,6 @@ DbObject::Shutdown()
             ItrObject::InitiateCloseRequest(itr_ptr);
 
     } while(again);
-#endif
 
     RefDec();
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -24,6 +24,7 @@
 #define INCL_REFOBJECTS_H
 
 #include <stdint.h>
+#include <sys/time.h>
 #include <list>
 
 #include "leveldb/db.h"
@@ -212,12 +213,19 @@ private:
 };  // class DbObject
 
 
+
+/****
+ ** Note Dec 18, 2013, matthewv:  LevelSnapshotWrapper and LevelIteratorWrapper
+ **  are left over from a design that did not perform as well as hoped.  There
+ **  so no reason why they could not be rolled into ItrObject.
+ ***/
+
 /**
  * A self deleting wrapper to contain leveldb snapshot pointer.
  *   Needed because multiple LevelIteratorWrappers could be using
  *   it ... and finishing at different times.
  */
-
+#if 0
 class LevelSnapshotWrapper : public RefObject
 {
 public:
@@ -255,7 +263,7 @@ private:
     LevelSnapshotWrapper& operator=(const LevelSnapshotWrapper &); // no assignment
 
 };  // LevelSnapshotWrapper
-
+#endif
 
 
 /**
@@ -269,26 +277,32 @@ class LevelIteratorWrapper : public RefObject
 {
 public:
     ReferencePtr<DbObject> m_DbPtr;           //!< need to keep db open for delete of this object
-    ReferencePtr<LevelSnapshotWrapper> m_Snap;//!< keep snapshot active while this object is
+    const leveldb::Snapshot * m_Snapshot;
     leveldb::Iterator * m_Iterator;
     volatile uint32_t m_HandoffAtomic;        //!< matthew's atomic foreground/background prefetch flag.
     bool m_KeysOnly;                          //!< only return key values
     bool m_PrefetchStarted;                   //!< true after first prefetch command
+    leveldb::ReadOptions * m_Options;           //!< shared copy of ItrObject::options
+    ERL_NIF_TERM itr_ref;                     //!< shared copy of ItrObject::itr_ref
 
-    LevelIteratorWrapper(DbObject * DbPtr, LevelSnapshotWrapper * Snapshot,
-                         leveldb::Iterator * Iterator, bool KeysOnly)
-        : m_DbPtr(DbPtr), m_Snap(Snapshot), m_Iterator(Iterator),
-        m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false)
+    // only used if m_Options.iterator_refresh == true
+    std::string m_RecentKey;                  //!< Most recent key returned
+    time_t m_IteratorStale;                   //!< time iterator should refresh
+    bool m_StillUse;                          //!< true if no error or key end seen
+
+    LevelIteratorWrapper(DbObject * DbPtr, bool KeysOnly,
+                         leveldb::ReadOptions * Options, ERL_NIF_TERM itr_ref)
+        : m_DbPtr(DbPtr), m_Snapshot(NULL), m_Iterator(NULL),
+        m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false),
+        m_Options(Options), itr_ref(itr_ref),
+        m_IteratorStale(0), m_StillUse(true)
     {
+        RebuildIterator();
     };
 
     virtual ~LevelIteratorWrapper()
     {
-        if (NULL!=m_Iterator)
-        {
-            delete m_Iterator;
-            m_Iterator=NULL;
-        }   // if
+        PurgeIterator();
     }   // ~LevelIteratorWrapper
 
     leveldb::Iterator * get() {return(m_Iterator);};
@@ -297,6 +311,36 @@ public:
     bool Valid() {return(m_Iterator->Valid());};
     leveldb::Slice key() {return(m_Iterator->key());};
     leveldb::Slice value() {return(m_Iterator->value());};
+
+    // iterator_refresh related routines
+    void PurgeIterator()
+    {
+        if (NULL!=m_Snapshot)
+        {
+            // leveldb performs actual "delete" call on m_Shapshot's pointer
+            m_DbPtr->m_Db->ReleaseSnapshot(m_Snapshot);
+            m_Snapshot=NULL;
+        }   // if
+
+        if (NULL!=m_Iterator)
+        {
+            delete m_Iterator;
+            m_Iterator=NULL;
+        }   // if
+    }   // PurgeIterator
+
+    void RebuildIterator()
+    {
+        struct timeval tv;
+
+        gettimeofday(&tv, NULL);
+        m_IteratorStale=tv.tv_sec + 300; // +5min
+
+        PurgeIterator();
+        m_Snapshot = m_DbPtr->m_Db->GetSnapshot();
+        m_Options->snapshot = m_Snapshot;
+        m_Iterator = m_DbPtr->m_Db->NewIterator(*m_Options);
+    }   // RebuildIterator
 
 private:
     LevelIteratorWrapper(const LevelIteratorWrapper &);            // no copy
@@ -314,14 +358,18 @@ class ItrObject : public ErlRefObject
 {
 public:
     ReferencePtr<LevelIteratorWrapper> m_Iter;
-    ReferencePtr<LevelSnapshotWrapper> m_Snapshot;
+//    ReferencePtr<LevelSnapshotWrapper> m_Snapshot;
 
     bool keys_only;
-    leveldb::ReadOptions * m_ReadOptions;
+    leveldb::ReadOptions * m_ReadOptions;  //!< Owned by this object, must delete
 
-    volatile class MoveTask * reuse_move;//!< iterator work object that is reused instead of lots malloc/free
+    volatile class MoveTask * reuse_move;  //!< iterator work object that is reused instead of lots malloc/free
 
     ReferencePtr<DbObject> m_DbPtr;
+
+    ERL_NIF_TERM itr_ref;                  //!< what was caller ref to async_iterator
+    ErlNifEnv *itr_ref_env;                //!< Erlang Env to hold itr_ref
+
 
 protected:
     static ErlNifResourceType* m_Itr_RESOURCE;

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -214,7 +214,7 @@ MoveTask::operator()()
                 if (!m_ItrWrap->m_StillUse)
                 {
                     itr=NULL;
-//                    m_ItrWrap->PurgeIterator();
+                    m_ItrWrap->PurgeIterator();
                 }   // if
             }   // if
         }   // if
@@ -264,7 +264,8 @@ MoveTask::operator()()
         {
             // release iterator now, not later
             m_ItrWrap->m_StillUse=false;
-// segfault            m_ItrWrap->PurgeIterator();
+            m_ItrWrap->PurgeIterator();
+            itr=NULL;
         }   // else
     }   // if
 
@@ -280,7 +281,7 @@ MoveTask::operator()()
         // setup next race for the response
         m_ItrWrap->m_HandoffAtomic=0;
 
-        if(itr->Valid())
+        if(NULL!=itr && itr->Valid())
         {
             if (PREFETCH==action)
                 prepare_recycle();

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -274,24 +274,16 @@ public:
     virtual work_result operator()()
     {
         ItrObject * itr_ptr;
-        const leveldb::Snapshot * snapshot;
-        leveldb::Iterator * iterator;
 
         // NOTE: transfering ownership of options to ItrObject
         itr_ptr=ItrObject::CreateItrObject(m_DbPtr.get(), keys_only, options);
 
-        snapshot = m_DbPtr->m_Db->GetSnapshot();
-        itr_ptr->m_Snapshot.assign(new LevelSnapshotWrapper(m_DbPtr.get(), snapshot));
-        options->snapshot = snapshot;
-
         // Copy caller_ref to reuse in future iterator_move calls
-        itr_ptr->m_Snapshot->itr_ref_env = enif_alloc_env();
-        itr_ptr->m_Snapshot->itr_ref = enif_make_copy(itr_ptr->m_Snapshot->itr_ref_env,
-                                                      caller_ref());
+        itr_ptr->itr_ref_env = enif_alloc_env();
+        itr_ptr->itr_ref = enif_make_copy(itr_ptr->itr_ref_env, caller_ref());
 
-        iterator = m_DbPtr->m_Db->NewIterator(*options);
-        itr_ptr->m_Iter.assign(new LevelIteratorWrapper(m_DbPtr.get(), itr_ptr->m_Snapshot.get(),
-                                                        iterator, keys_only));
+        itr_ptr->m_Iter.assign(new LevelIteratorWrapper(m_DbPtr.get(), keys_only,
+                                                        options, itr_ptr->itr_ref));
 
         ERL_NIF_TERM result = enif_make_resource(local_env(), itr_ptr);
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -100,7 +100,8 @@ init() ->
                          {delete_threshold, pos_integer()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
-                         {fill_cache, boolean()}].
+                         {fill_cache, boolean()} |
+                         {iterator_refresh, boolean()}].
 
 -type write_options() :: [{sync, boolean()}].
 
@@ -283,7 +284,8 @@ option_types(open) ->
 
 option_types(read) ->
     [{verify_checksums, bool},
-     {fill_cache, bool}];
+     {fill_cache, bool},
+     {iterator_refresh, bool}];
 option_types(write) ->
      [{sync, bool}].
 


### PR DESCRIPTION
Special case code:  when an iterator is held for a long, long time AND its database (vnode) is under heavy write load, the snapshot held by the iterator can cause that database thrash.  If this iterator is ONLY processing NEXT operations, this branch will close and reopen the iterator every 5 minutes.  Intended primarily for internal Riak operations such as AAE.

Notes here:  https://github.com/basho/leveldb/wiki/mv-iterator-refresh
