### PR TITLE
restore AAE exemption to writeblock size accounting in write throttle

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="1.4.4"
+LEVELDB_VSN="mv-aae-writeblock"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -122,6 +122,7 @@ ERL_NIF_TERM ATOM_KEYS_ONLY;
 ERL_NIF_TERM ATOM_COMPRESSION;
 ERL_NIF_TERM ATOM_ERROR_DB_REPAIR;
 ERL_NIF_TERM ATOM_USE_BLOOMFILTER;
+ERL_NIF_TERM ATOM_IS_INTERNAL_DB;
 ERL_NIF_TERM ATOM_WRITE_THREADS;
 ERL_NIF_TERM ATOM_FADVISE_WILLNEED;
 
@@ -301,6 +302,13 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             {
                 opts.filter_policy = leveldb::NewBloomFilterPolicy2(bfsize);
             }
+        }
+        else if (option[0] == eleveldb::ATOM_IS_INTERNAL_DB)
+        {
+            if (option[1] == eleveldb::ATOM_TRUE)
+                opts.is_internal_db = true;
+            else
+                opts.is_internal_db = false;
         }
     }
 
@@ -1009,6 +1017,7 @@ try
     ATOM(eleveldb::ATOM_KEYS_ONLY, "keys_only");
     ATOM(eleveldb::ATOM_COMPRESSION, "compression");
     ATOM(eleveldb::ATOM_USE_BLOOMFILTER, "use_bloomfilter");
+    ATOM(eleveldb::ATOM_IS_INTERNAL_DB, "is_internal_db");
     ATOM(eleveldb::ATOM_WRITE_THREADS, "write_threads");
     ATOM(eleveldb::ATOM_FADVISE_WILLNEED, "fadvise_willneed");
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -95,6 +95,7 @@ init() ->
                          {verify_compactions, boolean()} |
                          {compression, boolean()} |
                          {use_bloomfilter, boolean() | pos_integer()} |
+                         {is_internal_db, boolean()} |
                          {fadvise_willneed, boolean()} |
                          {write_threads, pos_integer()}].
 
@@ -270,6 +271,7 @@ option_types(open) ->
      {verify_compactions, bool},
      {compression, bool},
      {use_bloomfilter, any},
+     {is_internal_db, bool},
      {write_threads, integer}];
 option_types(read) ->
     [{verify_checksums, bool},


### PR DESCRIPTION
Restore AAE exemption to writeblock size accounting in write throttle, BUT leave the accounting for 2i writeblocks.  Required back-porting of Riak 2.0 is_internal_db flag
