### PR TITLE
Mv tuning6

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -177,7 +177,7 @@ struct EleveldbOptions
     int m_LeveldbGroomingThreads;
 
     int m_TotalMemPercent;
-    int m_TotalMem;
+    size_t m_TotalMem;
 
     bool m_LimitedDeveloper;
     bool m_FadviseWillNeed;
@@ -199,7 +199,7 @@ struct EleveldbOptions
         syslog(LOG_ERR, "  m_LeveldbGroomingThreads: %d\n", m_LeveldbGroomingThreads);
 
         syslog(LOG_ERR, "         m_TotalMemPercent: %d\n", m_TotalMemPercent);
-        syslog(LOG_ERR, "                m_TotalMem: %d\n", m_TotalMem);
+        syslog(LOG_ERR, "                m_TotalMem: %zd\n", m_TotalMem);
 
         syslog(LOG_ERR, "        m_LimitedDeveloper: %s\n", (m_LimitedDeveloper ? "true" : "false"));
         syslog(LOG_ERR, "         m_FadviseWillNeed: %s\n", (m_FadviseWillNeed ? "true" : "false"));
@@ -237,12 +237,12 @@ ERL_NIF_TERM parse_init_option(ErlNifEnv* env, ERL_NIF_TERM item, EleveldbOption
     {
         if (option[0] == eleveldb::ATOM_TOTAL_LEVELDB_MEM)
         {
-            unsigned long memory_sz;
+            size_t memory_sz;
             if (enif_get_ulong(env, option[1], &memory_sz))
             {
                 if (memory_sz != 0)
                 {
-                     opts.m_TotalMem = memory_sz;
+                    opts.m_TotalMem = memory_sz;
                 }
             }
         }

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -125,6 +125,7 @@ ERL_NIF_TERM ATOM_USE_BLOOMFILTER;
 ERL_NIF_TERM ATOM_TOTAL_MEMORY;
 ERL_NIF_TERM ATOM_TOTAL_LEVELDB_MEM;
 ERL_NIF_TERM ATOM_TOTAL_LEVELDB_MEM_PERCENT;
+ERL_NIF_TERM ATOM_BLOCK_CACHE_THRESHOLD;
 ERL_NIF_TERM ATOM_IS_INTERNAL_DB;
 ERL_NIF_TERM ATOM_LIMITED_DEVELOPER_MEM;
 ERL_NIF_TERM ATOM_ELEVELDB_THREADS;
@@ -322,6 +323,17 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             unsigned long block_steps(0);
             if (enif_get_ulong(env, option[1], &block_steps))
              opts.block_size_steps = block_steps;
+        }
+        else if (option[0] == eleveldb::ATOM_BLOCK_CACHE_THRESHOLD)
+        {
+            size_t memory_sz;
+            if (enif_get_ulong(env, option[1], &memory_sz))
+            {
+                if (memory_sz != 0)
+                {
+                    opts.block_cache_threshold = memory_sz;
+                }
+            }
         }
         else if (option[0] == eleveldb::ATOM_DELETE_THRESHOLD)
         {
@@ -1170,6 +1182,7 @@ try
     ATOM(eleveldb::ATOM_TOTAL_MEMORY, "total_memory");
     ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM, "total_leveldb_mem");
     ATOM(eleveldb::ATOM_TOTAL_LEVELDB_MEM_PERCENT, "total_leveldb_mem_percent");
+    ATOM(eleveldb::ATOM_BLOCK_CACHE_THRESHOLD, "block_cache_threshold");
     ATOM(eleveldb::ATOM_IS_INTERNAL_DB, "is_internal_db");
     ATOM(eleveldb::ATOM_LIMITED_DEVELOPER_MEM, "limited_developer_mem");
     ATOM(eleveldb::ATOM_ELEVELDB_THREADS, "eleveldb_threads");

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -19,13 +19,13 @@
 %% instead.
 %% @see leveldb.maximum_memory
 {mapping, "leveldb.maximum_memory.percent", "eleveldb.total_leveldb_mem_percent", [
-  {default, "80"},
+  {default, "70"},
   {datatype, integer}
 ]}.
 
 %% @see leveldb.maximum_memory.percent
 {mapping, "multi_backend.$name.leveldb.maximum_memory.percent", "riak_kv.multi_backend", [
-  {default, "45"},
+  {default, "35"},
   {datatype, integer},
   {level, advanced}
 ]}.
@@ -139,14 +139,14 @@
 %% regard to release in favor of file cache.  The value is per
 %% vnode.
 {mapping, "leveldb.block_cache_threshold", "eleveldb.block_cache_threshold", [
-  {default, "16MB"},
+  {default, "32MB"},
   {datatype, bytesize},
   hidden
 ]}.
 
 %% @see leveldb.block_cache_threshold
 {mapping, "multi_backend.$name.leveldb.block_cache_threshold", "riak_kv.multi_backend", [
-  {default, "16MB"},
+  {default, "32MB"},
   {datatype, bytesize},
   hidden
 ]}.

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -134,6 +134,23 @@
   {level, advanced}
 ]}.
 
+%% @doc Defines the limit where block cache memory can no longer be
+%% released in favor of the page cache.  This has no impact with
+%% regard to release in favor of file cache.  The value is per
+%% vnode.
+{mapping, "leveldb.block_cache_threshold", "eleveldb.block_cache_threshold", [
+  {default, "16MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
+%% @see leveldb.block_cache_threshold
+{mapping, "multi_backend.$name.leveldb.block_cache_threshold", "riak_kv.multi_backend", [
+  {default, "16MB"},
+  {datatype, bytesize},
+  {level, advanced}
+]}.
+
 %% @doc Defines the size threshold for a block / chunk of data within
 %% one .sst table file. Each new block gets an index entry in the .sst
 %% table file's master index.

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -141,14 +141,14 @@
 {mapping, "leveldb.block_cache_threshold", "eleveldb.block_cache_threshold", [
   {default, "16MB"},
   {datatype, bytesize},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @see leveldb.block_cache_threshold
 {mapping, "multi_backend.$name.leveldb.block_cache_threshold", "riak_kv.multi_backend", [
   {default, "16MB"},
   {datatype, bytesize},
-  {level, advanced}
+  hidden
 ]}.
 
 %% @doc Defines the size threshold for a block / chunk of data within

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -97,6 +97,7 @@ init() ->
                          {limited_developer_mem, boolean()} |
                          {eleveldb_threads, pos_integer()} |
                          {fadvise_willneed, boolean()} |
+                         {block_cache_threshold, pos_integer()} |
                          {delete_threshold, pos_integer()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
@@ -280,6 +281,7 @@ option_types(open) ->
      {limited_developer_mem, bool},
      {eleveldb_threads, integer},
      {fadvise_willneed, bool},
+     {block_cache_threshold, integer},
      {delete_threshold, integer}];
 
 option_types(read) ->


### PR DESCRIPTION
Detail description here:  https://github.com/basho/leveldb/wiki/mv-tuning6

This branch requires manual pull of leveldb's mv-tuning6 branch to compile.

Adds block_cache_threshold parameter to options interfaces.  Corrects an incorrect type on m_TotalMem member of EleveldbOptions structure.
