### PR TITLE
correct prefetch race condition.

### DIFF
--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -13,7 +13,7 @@ basic_schema_test() ->
         ["../priv/eleveldb.schema"], [], context(), predefined_schema()),
 
     cuttlefish_unit:assert_config(Config, "eleveldb.data_root", "./data/leveldb"),
-    cuttlefish_unit:assert_config(Config, "eleveldb.total_leveldb_mem_percent", 80),
+    cuttlefish_unit:assert_config(Config, "eleveldb.total_leveldb_mem_percent", 70),
     cuttlefish_unit:assert_not_configured(Config, "eleveldb.total_leveldb_mem"),
     cuttlefish_unit:assert_config(Config, "eleveldb.sync", false),
     cuttlefish_unit:assert_config(Config, "eleveldb.limited_developer_mem", false),


### PR DESCRIPTION
This PR corrects a race condition in the iterator prefetch.  The race was found using 5 node cluster with bitcask backend.  AAE's use of leveldb triggered the race and resulted in segfault.  All is good now.
