### PR TITLE
Mv compress option

### DIFF
--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -152,14 +152,14 @@
   hidden
 ]}.
 
-%% @doc Enables or disables the compression of data on disk.  
+%% @doc Enables or disables the compression of data on disk.
 %% Enabling (default) saves disk space.  Disabling may reduce read
-%% latency but increase overall disk activity.  Option can be 
-%% changed at any time, but will not impact data on disk until 
+%% latency but increase overall disk activity.  Option can be
+%% changed at any time, but will not impact data on disk until
 %% next time a file requires compaction.
 {mapping, "leveldb.compression", "eleveldb.compression", [
-  {default, true},
-  {datatype, {enum, [true, false]}},
+  {default, on},
+  {datatype, flag},
   hidden
 ]}.
 

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -152,6 +152,17 @@
   hidden
 ]}.
 
+%% @doc Enables or disables the compression of data on disk.  
+%% Enabling (default) saves disk space.  Disabling may reduce read
+%% latency but increase overall disk activity.  Option can be 
+%% changed at any time, but will not impact data on disk until 
+%% next time a file requires compaction.
+{mapping, "leveldb.compression", "eleveldb.compression", [
+  {default, true},
+  {datatype, {enum, [true, false]}},
+  hidden
+]}.
+
 %% @doc Controls when a background compaction initiates solely
 %% due to the number of delete tombstones within an individual
 %% .sst table file.  Value of 'off' disables the feature.

--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -112,6 +112,15 @@
   hidden
 ]}.
 
+%% @see leveldb.compression
+{mapping,
+  "multi_backend.$name.leveldb.compression",
+  "riak_kv.multi_backend", [
+  {default, true},
+  {datatype, {enum, [true, false]}},
+  hidden
+]}.
+
 %% @see leveldb.delete_threshold
 {mapping,
   "multi_backend.$name.leveldb.compaction.trigger.tombstone_count",

--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -116,8 +116,8 @@
 {mapping,
   "multi_backend.$name.leveldb.compression",
   "riak_kv.multi_backend", [
-  {default, true},
-  {datatype, {enum, [true, false]}},
+  {default, on},
+  {datatype, flag},
   hidden
 ]}.
 

--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -27,6 +27,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "eleveldb.eleveldb_threads", 71),
     cuttlefish_unit:assert_config(Config, "eleveldb.fadvise_willneed", false),
     cuttlefish_unit:assert_config(Config, "eleveldb.delete_threshold", 1000),
+    cuttlefish_unit:assert_config(Config, "eleveldb.compression", true),
     %% Make sure no multi_backend
     %% Warning: The following line passes by coincidence. It's because the
     %% first mapping in the schema has no default defined. Testing strategy
@@ -52,6 +53,7 @@ override_schema_test() ->
             {["leveldb", "verify_compaction"], off},
             {["leveldb", "threads"], 7},
             {["leveldb", "fadvise_willneed"], true},
+            {["leveldb", "compression"], off},
             {["leveldb", "compaction", "trigger", "tombstone_count"], off}
            ],
 
@@ -75,6 +77,7 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "eleveldb.eleveldb_threads", 7),
     cuttlefish_unit:assert_config(Config, "eleveldb.fadvise_willneed", true),
     cuttlefish_unit:assert_config(Config, "eleveldb.delete_threshold", 0),
+    cuttlefish_unit:assert_config(Config, "eleveldb.compression", false),
 
     %% Make sure no multi_backend
     %% Warning: The following line passes by coincidence. It's because the


### PR DESCRIPTION
Bring the compression option to cuttlefish.  Developers want it (namely Matthew) and customers on mailing list are talking about how they disable compression in favor of ZFS compression.  This needs to be available.
