### PR TITLE
Mv tiered options

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -131,7 +131,9 @@ ERL_NIF_TERM ATOM_LIMITED_DEVELOPER_MEM;
 ERL_NIF_TERM ATOM_ELEVELDB_THREADS;
 ERL_NIF_TERM ATOM_FADVISE_WILLNEED;
 ERL_NIF_TERM ATOM_DELETE_THRESHOLD;
-
+ERL_NIF_TERM ATOM_TIERED_SLOW_LEVEL;
+ERL_NIF_TERM ATOM_TIERED_FAST_PREFIX;
+ERL_NIF_TERM ATOM_TIERED_SLOW_PREFIX;
 }   // namespace eleveldb
 
 
@@ -422,6 +424,32 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
             else
                 opts.limited_developer_mem = false;
         }
+
+        else if (option[0] == eleveldb::ATOM_TIERED_SLOW_LEVEL)
+        {
+            int tiered_level;
+            if (enif_get_int(env, option[1], &tiered_level))
+                opts.tiered_slow_level = tiered_level;
+        }
+        else if (option[0] == eleveldb::ATOM_TIERED_FAST_PREFIX)
+        {
+            char buffer[256];
+            int ret_val;
+
+            ret_val=enif_get_string(env, option[1], buffer, 256, ERL_NIF_LATIN1);
+            if (0<ret_val && ret_val<256)
+                opts.tiered_fast_prefix = buffer;
+        }
+        else if (option[0] == eleveldb::ATOM_TIERED_SLOW_PREFIX)
+        {
+            char buffer[256];
+            int ret_val;
+
+            ret_val=enif_get_string(env, option[1], buffer, 256, ERL_NIF_LATIN1);
+            if (0<ret_val && ret_val<256)
+                opts.tiered_slow_prefix = buffer;
+        }
+
     }
 
     return eleveldb::ATOM_OK;
@@ -1194,7 +1222,9 @@ try
     ATOM(eleveldb::ATOM_ELEVELDB_THREADS, "eleveldb_threads");
     ATOM(eleveldb::ATOM_FADVISE_WILLNEED, "fadvise_willneed");
     ATOM(eleveldb::ATOM_DELETE_THRESHOLD, "delete_threshold");
-
+    ATOM(eleveldb::ATOM_TIERED_SLOW_LEVEL, "tiered_slow_level");
+    ATOM(eleveldb::ATOM_TIERED_FAST_PREFIX, "tiered_fast_prefix");
+    ATOM(eleveldb::ATOM_TIERED_SLOW_PREFIX, "tiered_slow_prefix");
 #undef ATOM
 
 

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -187,7 +187,7 @@
 %% stored at the chosen level or greater will be stored on
 %% leveldb.tiered.mounts.slow, while everything at the levels below will
 %% be stored on leveldb.tiered.mounts.fast
-%% Levels 3 or 4 are reccomend settings.
+%% Levels 3 or 4 are recommend settings.
 %% WARNING: There is no dynamic reallocation of leveldb
 %% data across mounts.  If you change this setting without manually
 %% moving the level files to the correct mounts, leveldb will act in

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -183,11 +183,11 @@
 
 %% @doc leveldb can be configured to use different mounts for
 %% different levels. This tiered option defaults to off, but you can
-%% configure it to trigger at levels 1-6. If you do this anything
+%% configure it to trigger at levels 1-6. If you do this, anything
 %% stored at the chosen level or greater will be stored on
-%% leveldb.tiered.mounts.slow, while everything at a level below will
+%% leveldb.tiered.mounts.slow, while everything at the levels below will
 %% be stored on leveldb.tiered.mounts.fast
-%% Levels 3-4 are reccomend settings.
+%% Levels 3 or 4 are reccomend settings.
 %% WARNING: There is no dynamic reallocation of leveldb
 %% data across mounts.  If you change this setting without manually
 %% moving the level files to the correct mounts, leveldb will act in
@@ -218,13 +218,13 @@
 }.
 
 %% @see leveldb.tiered
-{mapping, "leveldb.tiered.mountpoint.fast", "eleveldb.tiered_fast_prefix", [
+{mapping, "leveldb.tiered.path.fast", "eleveldb.tiered_fast_prefix", [
   {datatype, directory},
   hidden
 ]}.
 
 %% @see leveldb.tiered
-{mapping, "leveldb.tiered.mountpoint.slow", "eleveldb.tiered_slow_prefix", [
+{mapping, "leveldb.tiered.path.slow", "eleveldb.tiered_slow_prefix", [
   {datatype, directory},
   hidden
 ]}.

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -180,3 +180,34 @@
        Int -> Int
    end
  end}.
+
+%% @doc The leveldb level number at which data is stored
+%%  based upon "tiered_slow_prefix" instead of "tiered_fast_prefix".
+%%  Default is zero which disables the option.  Valid values are
+%%  1 to 6 (3 or 4 recommended).
+{mapping, "leveldb.tiered_slow_level", "eleveldb.tiered_slow_level", [
+  {default, 0},
+  {datatype, integer},
+  hidden
+]}.
+
+
+%% @doc When tiered_slow_level is set, this option specifies
+%% the path prefix used for a "fast" disk array.  levels 0 to
+%% tiered_slow_prefix-1 use this path prefix.
+{mapping, "leveldb.tiered_fast_prefix", "eleveldb.tiered_fast_prefix", [
+  {datatype, directory},
+  {default, ""},
+  hidden
+]}.
+
+
+%% @doc When tiered_slow_level is set, this option specifies
+%% the path prefix used for a "slow" disk array.  levels tiered_slow_prefix
+%% through 6 use this path prefix
+{mapping, "leveldb.tiered_slow_prefix", "eleveldb.tiered_slow_prefix", [
+  {datatype, directory},
+  {default, ""},
+  hidden
+]}.
+

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -181,33 +181,50 @@
    end
  end}.
 
-%% @doc The leveldb level number at which data is stored
-%%  based upon "tiered_slow_prefix" instead of "tiered_fast_prefix".
-%%  Default is zero which disables the option.  Valid values are
-%%  1 to 6 (3 or 4 recommended).
-{mapping, "leveldb.tiered_slow_level", "eleveldb.tiered_slow_level", [
-  {default, 0},
-  {datatype, integer},
+%% @doc leveldb can be configured to use different mounts for
+%% different levels. This tiered option defaults to off, but you can
+%% configure it to trigger at levels 1-6. If you do this anything
+%% stored at the chosen level or greater will be stored on
+%% leveldb.tiered.mounts.slow, while everything at a level below will
+%% be stored on leveldb.tiered.mounts.fast
+%% Levels 3-4 are reccomend settings.
+%% WARNING: There is no dynamic reallocation of leveldb
+%% data across mounts.  If you change this setting without manually
+%% moving the level files to the correct mounts, leveldb will act in
+%% an unexpected state.
+%% @see leveldb.tiered.mounts.fast
+%% @see leveldb.tiered.mounts.slow
+{mapping, "leveldb.tiered", "eleveldb.tiered_slow_level", [
+  {default, off},
+  {datatype, [
+              {atom, off},
+              {integer, 1},
+              {integer, 2},
+              {integer, 3},
+              {integer, 4},
+              {integer, 5},
+              {integer, 6}
+             ]},
   hidden
 ]}.
 
+{translation, "eleveldb.tiered_slow_level",
+ fun(Conf) ->
+    case cuttlefish:conf_get("leveldb.tiered", Conf) of
+        off -> 0;
+        I -> I
+    end
+ end
+}.
 
-%% @doc When tiered_slow_level is set, this option specifies
-%% the path prefix used for a "fast" disk array.  levels 0 to
-%% tiered_slow_prefix-1 use this path prefix.
-{mapping, "leveldb.tiered_fast_prefix", "eleveldb.tiered_fast_prefix", [
+%% @see leveldb.tiered
+{mapping, "leveldb.tiered.mountpoint.fast", "eleveldb.tiered_fast_prefix", [
   {datatype, directory},
-  {default, ""},
   hidden
 ]}.
 
-
-%% @doc When tiered_slow_level is set, this option specifies
-%% the path prefix used for a "slow" disk array.  levels tiered_slow_prefix
-%% through 6 use this path prefix
-{mapping, "leveldb.tiered_slow_prefix", "eleveldb.tiered_slow_prefix", [
+%% @see leveldb.tiered
+{mapping, "leveldb.tiered.mountpoint.slow", "eleveldb.tiered_slow_prefix", [
   {datatype, directory},
-  {default, ""},
   hidden
 ]}.
-

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -187,7 +187,7 @@
 %% stored at the chosen level or greater will be stored on
 %% leveldb.tiered.mounts.slow, while everything at the levels below will
 %% be stored on leveldb.tiered.mounts.fast
-%% Levels 3 or 4 are recommend settings.
+%% Levels 3 or 4 are recommended settings.
 %% WARNING: There is no dynamic reallocation of leveldb
 %% data across mounts.  If you change this setting without manually
 %% moving the level files to the correct mounts, leveldb will act in

--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -128,3 +128,30 @@
   {datatype, [integer, {atom, off}]},
   hidden
 ]}.
+
+%% @see leveldb.tiered_slow_level
+{mapping, "multi_backend.$name.leveldb.tiered_slow_level",
+  "riak_kv.multi_backend", [
+  {default, 0},
+  {datatype, integer},
+  hidden
+]}.
+
+
+%% @see leveldb.tiered_fast_prefix
+{mapping, "multi_backend.$name.leveldb.tiered_fast_prefix",
+  "riak_kv.multi_backend", [
+  {datatype, directory},
+  {default, ""},
+  hidden
+]}.
+
+
+%% @see leveldb.tiered_slow_prefix
+{mapping, "multi_backend.$name.leveldb.tiered_slow_prefix",
+  "riak_kv.multi_backend", [
+  {datatype, directory},
+  {default, ""},
+  hidden
+]}.
+

--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -129,29 +129,29 @@
   hidden
 ]}.
 
-%% @see leveldb.tiered_slow_level
-{mapping, "multi_backend.$name.leveldb.tiered_slow_level",
-  "riak_kv.multi_backend", [
-  {default, 0},
-  {datatype, integer},
+%% @see leveldb.tiered
+{mapping, "multi_backend.$name.leveldb.tiered", "riak_kv.multi_backend", [
+  {default, off},
+  {datatype, [
+              {atom, off},
+              {integer, 1},
+              {integer, 2},
+              {integer, 3},
+              {integer, 4},
+              {integer, 5},
+              {integer, 6}
+             ]},
   hidden
 ]}.
 
-
-%% @see leveldb.tiered_fast_prefix
-{mapping, "multi_backend.$name.leveldb.tiered_fast_prefix",
-  "riak_kv.multi_backend", [
+%% @see leveldb.tiered
+{mapping, "multi_backend.$name.leveldb.tiered.mountpoint.fast", "riak_kv.multi_backend", [
   {datatype, directory},
-  {default, ""},
   hidden
 ]}.
 
-
-%% @see leveldb.tiered_slow_prefix
-{mapping, "multi_backend.$name.leveldb.tiered_slow_prefix",
-  "riak_kv.multi_backend", [
+%% @see leveldb.tiered
+{mapping, "multi_backend.$name.leveldb.tiered.mountpoint.slow", "riak_kv.multi_backend", [
   {datatype, directory},
-  {default, ""},
   hidden
 ]}.
-

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -98,7 +98,10 @@ init() ->
                          {eleveldb_threads, pos_integer()} |
                          {fadvise_willneed, boolean()} |
                          {block_cache_threshold, pos_integer()} |
-                         {delete_threshold, pos_integer()}].
+                         {delete_threshold, pos_integer()} |
+                         {tiered_slow_level, pos_integer()} |
+                         {tiered_fast_prefix, string()} |
+                         {tiered_slow_prefix, string()}].
 
 -type read_options() :: [{verify_checksums, boolean()} |
                          {fill_cache, boolean()} |
@@ -282,7 +285,10 @@ option_types(open) ->
      {eleveldb_threads, integer},
      {fadvise_willneed, bool},
      {block_cache_threshold, integer},
-     {delete_threshold, integer}];
+     {delete_threshold, integer},
+     {tiered_slow_level, integer},
+     {tiered_fast_prefix, any},
+     {tiered_slow_prefix, any}];
 
 option_types(read) ->
     [{verify_checksums, bool},

--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -28,6 +28,10 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "eleveldb.fadvise_willneed", false),
     cuttlefish_unit:assert_config(Config, "eleveldb.delete_threshold", 1000),
     cuttlefish_unit:assert_config(Config, "eleveldb.compression", true),
+    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_level", 0),
+    cuttlefish_unit:assert_not_configured(Config, "eleveldb.tiered_fast_prefix"),
+    cuttlefish_unit:assert_not_configured(Config, "eleveldb.tiered_slow_prefix"),
+
     %% Make sure no multi_backend
     %% Warning: The following line passes by coincidence. It's because the
     %% first mapping in the schema has no default defined. Testing strategy
@@ -54,7 +58,10 @@ override_schema_test() ->
             {["leveldb", "threads"], 7},
             {["leveldb", "fadvise_willneed"], true},
             {["leveldb", "compression"], off},
-            {["leveldb", "compaction", "trigger", "tombstone_count"], off}
+            {["leveldb", "compaction", "trigger", "tombstone_count"], off},
+            {["leveldb", "tiered"], "2"},
+            {["leveldb", "tiered", "mountpoint", "fast"], "/dev/speedy"},
+            {["leveldb", "tiered", "mountpoint", "slow"], "/dev/slowpoke"}
            ],
 
     %% The defaults are defined in ../priv/eleveldb.schema.
@@ -78,6 +85,9 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "eleveldb.fadvise_willneed", true),
     cuttlefish_unit:assert_config(Config, "eleveldb.delete_threshold", 0),
     cuttlefish_unit:assert_config(Config, "eleveldb.compression", false),
+    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_level", 2),
+    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_fast_prefix", "/dev/speedy"),
+    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_prefix", "/dev/slowpoke"),
 
     %% Make sure no multi_backend
     %% Warning: The following line passes by coincidence. It's because the
@@ -94,7 +104,6 @@ multi_backend_test() ->
     Config = cuttlefish_unit:generate_templated_config(
                ["../priv/eleveldb.schema", "../priv/eleveldb_multi.schema", "../test/multi_backend.schema"],
                Conf, context(), predefined_schema()),
-    %%io:format("Config: ~p~n", []),
 
     MultiBackendConfig = proplists:get_value(multi_backend, proplists:get_value(riak_kv, Config)),
 

--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -60,8 +60,8 @@ override_schema_test() ->
             {["leveldb", "compression"], off},
             {["leveldb", "compaction", "trigger", "tombstone_count"], off},
             {["leveldb", "tiered"], "2"},
-            {["leveldb", "tiered", "mountpoint", "fast"], "/dev/speedy"},
-            {["leveldb", "tiered", "mountpoint", "slow"], "/dev/slowpoke"}
+            {["leveldb", "tiered", "path", "fast"], "/mnt/speedy"},
+            {["leveldb", "tiered", "path", "slow"], "/mnt/slowpoke"}
            ],
 
     %% The defaults are defined in ../priv/eleveldb.schema.
@@ -86,8 +86,8 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "eleveldb.delete_threshold", 0),
     cuttlefish_unit:assert_config(Config, "eleveldb.compression", false),
     cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_level", 2),
-    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_fast_prefix", "/dev/speedy"),
-    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_prefix", "/dev/slowpoke"),
+    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_fast_prefix", "/mnt/speedy"),
+    cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_prefix", "/mnt/slowpoke"),
 
     %% Make sure no multi_backend
     %% Warning: The following line passes by coincidence. It's because the

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -11,8 +11,31 @@
   hidden
 ]}.
 
-{translation, "riak_kv.multi_backend",
+{translation,
+ "riak_kv.multi_backend",
  fun(Conf, Schema) ->
+  GenerateSubConfig = fun(Name, Prefix, ProplistKey, ModuleName) ->
+      BackendConfigName = ["multi_backend", Name],
+      BackendConfigPrefix = BackendConfigName ++ [Prefix],
+      SubConf = [ begin
+          {lists:nthtail(2, Key), Value}
+      end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
+
+      case cuttlefish_generator:map(Schema, SubConf) of
+        {error, _Phase, {error, Errors}} ->
+            [ io:format("~s~n", [E]) || {error, E} <- Errors ],
+            cuttlefish:invalid(
+              lists:flatten(io_lib:format(
+                "Error processing multi_backend configuration for backend ~s", [Name])));
+        BackendProplist ->
+          Proplist = lists:foldl(
+          fun(K, Acc) ->
+            proplists:get_value(K, Acc, [])
+          end,
+          BackendProplist, ProplistKey),
+          {ModuleName, Proplist}
+      end
+  end,
   %% group by $name into list, also cut the "multi_backend.$name" off every key
   BackendNames = cuttlefish_variable:fuzzy_matches(["multi_backend","$name","storage_backend"], Conf),
   %% for each in list, case statement on backend type
@@ -20,19 +43,13 @@
     BackendConfigName = ["multi_backend", Name],
     {BackendModule, BackendConfig} = case cuttlefish:conf_get(BackendConfigName ++ ["storage_backend"], Conf) of
       leveldb ->
-        BackendConfigPrefix = BackendConfigName ++ ["leveldb"],
-        SubConf = [ begin
-          {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
-
-        BackendProplist = cuttlefish_generator:map(Schema, SubConf),
-
-        {riak_kv_eleveldb_backend, proplists:get_value(eleveldb, BackendProplist)}
-    end,
+        GenerateSubConfig(Name, "leveldb", [eleveldb], riak_kv_eleveldb_backend)
+      end,
     {list_to_binary(Name),  BackendModule, BackendConfig}
   end || {"$name", Name} <- BackendNames],
   case Backends of
       [] -> throw(unset);
       _ -> Backends
   end
- end}.
+ end
+}.


### PR DESCRIPTION
Add options necessary to support tiered storage based upon the sst_? directories (introduced in Riak 1.3).

Branch discussion is here:
    https://github.com/basho/leveldb/wiki/mv-tiered-options

Merge Requirements
- [ ] Eng +1
- [x] CSE +1
- [x] ProdMgmt + 1
