### PR TITLE
avoid badarg exception when closing db_refs being closed

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -947,10 +947,11 @@ eleveldb_close(
 {
     eleveldb::DbObject * db_ptr;
     ERL_NIF_TERM ret_term;
+    bool term_ok=false;
 
     ret_term=eleveldb::ATOM_OK;
 
-    db_ptr=eleveldb::DbObject::RetrieveDbObject(env, argv[0]);
+    db_ptr=eleveldb::DbObject::RetrieveDbObject(env, argv[0], &term_ok);
 
     if (NULL!=db_ptr)
     {
@@ -961,7 +962,7 @@ eleveldb_close(
 
         ret_term=eleveldb::ATOM_OK;
     }   // if
-    else
+    else if (!term_ok)
     {
         ret_term=enif_make_badarg(env);
     }   // else

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -2,7 +2,7 @@
 //
 // eleveldb: Erlang Wrapper for LevelDB (http://code.google.com/p/leveldb/)
 //
-// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+// Copyright (c) 2011-2014 Basho Technologies, Inc. All Rights Reserved.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -237,14 +237,24 @@ DbObject::CreateDbObject(
 DbObject *
 DbObject::RetrieveDbObject(
     ErlNifEnv * Env,
-    const ERL_NIF_TERM & DbTerm)
+    const ERL_NIF_TERM & DbTerm,
+    bool * term_ok)
 {
     DbObject * ret_ptr;
 
     ret_ptr=NULL;
+    if (NULL!=term_ok)
+    {
+        *term_ok=false;
+    }
 
     if (enif_get_resource(Env, DbTerm, m_Db_RESOURCE, (void **)&ret_ptr))
     {
+        if (NULL!=term_ok)
+        {
+            *term_ok=true;
+        }
+
         // has close been requested?
         if (ret_ptr->m_CloseRequested)
         {

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -2,7 +2,7 @@
 //
 // eleveldb: Erlang Wrapper for LevelDB (http://code.google.com/p/leveldb/)
 //
-// Copyright (c) 2011-2013 Basho Technologies, Inc. All Rights Reserved.
+// Copyright (c) 2011-2014 Basho Technologies, Inc. All Rights Reserved.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -202,7 +202,7 @@ public:
 
     static DbObject * CreateDbObject(leveldb::DB * Db, leveldb::Options * DbOptions);
 
-    static DbObject * RetrieveDbObject(ErlNifEnv * Env, const ERL_NIF_TERM & DbTerm);
+    static DbObject * RetrieveDbObject(ErlNifEnv * Env, const ERL_NIF_TERM & DbTerm, bool * term_ok=NULL);
 
     static void DbObjectResourceCleanup(ErlNifEnv *Env, void * Arg);
 


### PR DESCRIPTION
DbObject::RetrieveDbObject() returns NULL for 2 cases: when the db_ref NIF
resource can't be retrieved, and when the "close requested" flag is already
set. But eleveldb_close() treats both NULL return cases as an error and
raises the badarg exception for both.

Modify DbObject::RetrieveDbObject() to add a defaulted third argument, a
pointer to bool that defaults to NULL. If non-NULL,
DbObject::RetrieveDbObject() sets the bool to true if the db_ref NIF
resource is successfully retrieved, false otherwise. This allows
eleveldb_close() to pass that bool argument and then use it to distinguish
between the two NULL return cases from DbObject::RetrieveDbObject().
