### PR TITLE
Mv iter close fix

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -772,7 +772,7 @@ async_iterator_move(
 
     itr_ptr.assign(ItrObject::RetrieveItrObject(env, itr_handle_ref));
 
-    if(NULL==itr_ptr.get())
+    if(NULL==itr_ptr.get() || 0!=itr_ptr->m_CloseRequested)
         return enif_make_badarg(env);
 
     // Reuse ref from iterator creation

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -954,7 +954,8 @@ async_close(
     // verify that Erlang has not called DbObjectResourceCleanup
     //  already (that would be bad)
     if (NULL!=db_ptr->m_Db
-        && compare_and_swap(db_ptr->m_ErlangThisPtr, db_ptr.get(), (DbObject *)NULL))
+//        && compare_and_swap(db_ptr->m_ErlangThisPtr, db_ptr.get(), (DbObject *)NULL))
+        && db_ptr->ClaimCloseFromCThread())
     {
         eleveldb::WorkTask *work_item = new eleveldb::CloseTask(env, caller_ref,
                                                                 db_ptr.get());
@@ -998,7 +999,8 @@ async_iterator_close(
 
     // verify that Erlang has not called ItrObjectResourceCleanup AND
     //  that a database close has not already started death proceedings
-    if (compare_and_swap(itr_ptr->m_ErlangThisPtr, itr_ptr.get(), (ItrObject *)NULL))
+//    if (compare_and_swap(itr_ptr->m_ErlangThisPtr, itr_ptr.get(), (ItrObject *)NULL))
+    if (itr_ptr->ClaimCloseFromCThread())
     {
         eleveldb::WorkTask *work_item = new eleveldb::ItrCloseTask(env, caller_ref,
                                                                    itr_ptr.get());

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -139,7 +139,8 @@ ErlRefObject::InitiateCloseRequest()
     pthread_mutex_lock(&m_CloseMutex);
 
     // one ref from construction, one ref from broadcast in RefDec below
-    if (1<m_RefCount)
+    //  (only wait if RefDec has not signaled)
+    if (0<m_RefCount && 1==m_CloseRequested)
     {
         pthread_cond_wait(&m_CloseCond, &m_CloseMutex);
     }   // while
@@ -169,7 +170,7 @@ ErlRefObject::RefDec()
         m_CloseRequested=2;
 
         // is there really more than one ref count now?
-        flag=(0<cur_count);
+        flag=(0<m_RefCount);
         if (flag)
         {
             RefObject::RefInc();

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -566,6 +566,14 @@ ItrObject::Shutdown()
     //   release when move object destructs)
     ReleaseReuseMove();
 
+    // only need this to create new Move objects,
+    //  get rid of it early
+    if (NULL!=itr_ref_env)
+    {
+        enif_free_env(itr_ref_env);
+        itr_ref_env=NULL;
+    }   // if
+
     // ItrObject and m_Iter each hold pointers to other, release ours
     m_Iter.assign(NULL);
 

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -531,7 +531,8 @@ ItrObject::ItrObject(
     DbObject * DbPtr,
     bool KeysOnly,
     leveldb::ReadOptions & Options)
-    : keys_only(KeysOnly), m_ReadOptions(Options), reuse_move(NULL), m_DbPtr(DbPtr)
+    : keys_only(KeysOnly), m_ReadOptions(Options), reuse_move(NULL),
+      m_DbPtr(DbPtr), itr_ref_env(NULL)
 {
     if (NULL!=DbPtr)
         DbPtr->AddReference(this);

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -105,6 +105,8 @@ public:
 
     virtual void Shutdown()=0;
 
+    bool ClaimCloseFromCThread();
+
     void InitiateCloseRequest();
 
 private:

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -427,11 +427,13 @@ public:
             // itr_ptr no longer valid
             itr_ptr=NULL;
 
-            return(work_result(ATOM_OK));
+//            return(work_result(ATOM_OK));
+            return(work_result());  // no message
         }   // if
         else
         {
-            return work_result(local_env(), ATOM_ERROR, ATOM_BADARG);
+//            return work_result(local_env(), ATOM_ERROR, ATOM_BADARG);
+            return(work_result());  // no message
         }   // else
     }
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -211,8 +211,9 @@ iterator_move(_IRef, _Loc) ->
 -spec iterator_close(itr_ref()) -> ok.
 iterator_close(IRef) ->
     CallerRef = make_ref(),
-    async_iterator_close(CallerRef, IRef),
-    ?WAIT_FOR_REPLY(CallerRef).
+    async_iterator_close(CallerRef, IRef).
+
+%%    ?WAIT_FOR_REPLY(CallerRef).
 
 async_iterator_close(_CallerRef, _IRef) ->
     erlang:nif_error({error, not_loaded}).


### PR DESCRIPTION
Correct race condition in asynchronous close logic that leads to segfaults.  The bad code was merged to develop via the mv-tuning7 branch.

Detail discusssion is here:  https://github.com/basho/leveldb/wiki/mv-iter-close-fix
