### PR TITLE
Must wait until complete close of iterator finishes. 

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -999,7 +999,6 @@ async_iterator_close(
 
     // verify that Erlang has not called ItrObjectResourceCleanup AND
     //  that a database close has not already started death proceedings
-//    if (compare_and_swap(itr_ptr->m_ErlangThisPtr, itr_ptr.get(), (ItrObject *)NULL))
     if (itr_ptr->ClaimCloseFromCThread())
     {
         eleveldb::WorkTask *work_item = new eleveldb::ItrCloseTask(env, caller_ref,

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -427,13 +427,13 @@ public:
             // itr_ptr no longer valid
             itr_ptr=NULL;
 
-//            return(work_result(ATOM_OK));
-            return(work_result());  // no message
+            return(work_result(ATOM_OK));
+//            return(work_result());  // no message
         }   // if
         else
         {
-//            return work_result(local_env(), ATOM_ERROR, ATOM_BADARG);
-            return(work_result());  // no message
+            return work_result(local_env(), ATOM_ERROR, ATOM_BADARG);
+//            return(work_result());  // no message
         }   // else
     }
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -211,9 +211,8 @@ iterator_move(_IRef, _Loc) ->
 -spec iterator_close(itr_ref()) -> ok.
 iterator_close(IRef) ->
     CallerRef = make_ref(),
-    async_iterator_close(CallerRef, IRef).
-
-%%    ?WAIT_FOR_REPLY(CallerRef).
+    async_iterator_close(CallerRef, IRef),
+    ?WAIT_FOR_REPLY(CallerRef).
 
 async_iterator_close(_CallerRef, _IRef) ->
     erlang:nif_error({error, not_loaded}).


### PR DESCRIPTION
A previous hack allowing iterator close to return immediately created race condition that would lead to Erlang heap corruption/crash.  This could be an Erlang heap issue (unlikely) or an uncovered race condition elsewhere in the eleveldb NIF (more likely).  For now, the crash goes away when the iterator close call properly awaits a message saying leveldb's close has completed.
