### PR TITLE
Add missing first_key option

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -105,7 +105,8 @@ init() ->
 
 -type read_options() :: [{verify_checksums, boolean()} |
                          {fill_cache, boolean()} |
-                         {iterator_refresh, boolean()}].
+                         {iterator_refresh, boolean()} |
+                         {first_key, boolean()}].
 
 -type write_options() :: [{sync, boolean()}].
 


### PR DESCRIPTION
Since dialyzer is listing this as a break but this is a valid option.
