### PR TITLE
Async Put Support

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -25,6 +25,7 @@
          close/1,
          get/3,
          put/4,
+         async_put/5,
          delete/3,
          write/3,
          fold/4,
@@ -160,6 +161,11 @@ write(Ref, Updates, Opts) ->
     CallerRef = make_ref(),
     async_write(CallerRef, Ref, Updates, Opts),
     ?WAIT_FOR_REPLY(CallerRef).
+
+async_put(Ref, Context, Key, Value, Opts) ->
+    Updates = [{put, Key, Value}],
+    async_write(Context, Ref, Updates, Opts),
+    ok.
 
 -spec async_write(reference(), db_ref(), write_actions(), write_options()) -> ok.
 async_write(_CallerRef, _Ref, _Updates, _Opts) ->

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -162,6 +162,7 @@ write(Ref, Updates, Opts) ->
     async_write(CallerRef, Ref, Updates, Opts),
     ?WAIT_FOR_REPLY(CallerRef).
 
+-spec async_put(db_ref(), reference(), binary(), binary(), write_options()) -> ok.
 async_put(Ref, Context, Key, Value, Opts) ->
     Updates = [{put, Key, Value}],
     async_write(Context, Ref, Updates, Opts),


### PR DESCRIPTION
Expose the internal async put mechanism - callers can pass in a context to receive as a message on the calling process.
