### PR TITLE
Remove lager parse transform

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {port_sources, ["c_src/*.cc"]}.
 
-{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info]}.
+{erl_opts, [warnings_as_errors, debug_info]}.
 
 {deps, [
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}


### PR DESCRIPTION
Whilst debugging something where I disabled the cuttlefish dependency, I noticed that lager applied the lager parse transform without actually using lager anywhere. This patch removes the `lager_transform` from `erl_opts`. 
