### PR TITLE
Reverted first_key/last_key fold options to start_key/end_key.  This …

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -164,8 +164,8 @@ init() ->
 -type fold_options() :: [read_option() |
 			 {encoding, encoding()} |
                          {fold_method, fold_method()} |
-                         {first_key, binary()} |
-                         {last_key, binary() | undefined} |
+                         {start_key, binary()} |
+                         {end_key, binary() | undefined} |
                          {start_inclusive, boolean()} |
                          {end_inclusive, boolean()} |
                          {limit, pos_integer()} |
@@ -408,8 +408,8 @@ fold(Ref, Fun, Acc0, Opts) ->
             {ok, Itr} = iterator(Ref, Opts),
             do_itr_fold(Itr, Fun, Acc0, Opts);
         streaming ->
-            SKey = proplists:get_value(first_key, Opts, <<>>),
-            EKey = proplists:get_value(last_key, Opts),
+            SKey = proplists:get_value(start_key, Opts, <<>>),
+            EKey = proplists:get_value(end_key, Opts),
             {ok, StreamRef} = streaming_start(Ref, SKey, EKey, Opts),
             {_, AckRef} = StreamRef,
             try
@@ -427,8 +427,8 @@ foldtest1(Ref, Fun, Acc0, Opts) ->
             {ok, Itr} = iterator(Ref, Opts),
             do_itr_fold(Itr, Fun, Acc0, Opts);
         streaming ->
-            SKey = proplists:get_value(first_key, Opts, <<>>),
-            EKey = proplists:get_value(last_key, Opts),
+            SKey = proplists:get_value(start_key, Opts, <<>>),
+            EKey = proplists:get_value(end_key, Opts),
             {ok, StreamRef} = streaming_start(Ref, SKey, EKey, Opts),
             {_, AckRef} = StreamRef,
             try
@@ -441,7 +441,7 @@ foldtest1(Ref, Fun, Acc0, Opts) ->
 
 emlfold1(Ref, _, _, Opts) ->
     {ok, Itr} = iterator(Ref, Opts),
-    Start = proplists:get_value(first_key, Opts, first),
+    Start = proplists:get_value(start_key, Opts, first),
     true = is_binary(Start) or (Start == first),
     iterator_move(Itr, Start).
 
@@ -562,10 +562,10 @@ add_open_defaults(Opts) ->
 
 do_itr_fold(Itr, Fun, Acc0, Opts) ->
     try
-        %% Extract {first_key, binary()} and seek to that key as a starting
+        %% Extract {start_key, binary()} and seek to that key as a starting
         %% point for the iteration. The folding function should use throw if it
         %% wishes to terminate before the end of the fold.
-        Start = proplists:get_value(first_key, Opts, first),
+        Start = proplists:get_value(start_key, Opts, first),
         true = is_binary(Start) or (Start == first),
         fold_loop(iterator_move(Itr, Start), Itr, Fun, Acc0)
     after
@@ -678,7 +678,7 @@ fold_from_key_test_Z() ->
     ok = ?MODULE:put(Ref, <<"hij">>, <<"789">>, []),
     [<<"def">>, <<"hij">>] = lists:reverse(fold_keys(Ref,
                                                      fun(K, Acc) -> [K | Acc] end,
-                                                     [], [{first_key, <<"d">>}])).
+                                                     [], [{start_key, <<"d">>}])).
 
 destroy_test() -> [{destroy_test_Z(), l} || l <- lists:seq(1, 20)].
 destroy_test_Z() ->

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -903,8 +903,8 @@ scanSome_test() ->
     N = 100,
     putKeysObj(N),
     Opts=[{fold_method, streaming},
-	  {first_key, <<"key002">>},
-	  {last_key,  <<"key099">>},
+	  {start_key, <<"key002">>},
+	  {end_key,  <<"key099">>},
 	  {end_inclusive,  true}],
 
     FoldFun = fun({K,_V}, Acc) -> 
@@ -926,7 +926,7 @@ scanNoStart_test() ->
     putKeysObj(N),
     Opts=[{fold_method, streaming},
 	  {start_inclusive, false},
-	  {first_key, <<"key001">>}],
+	  {start_key, <<"key001">>}],
 
     FoldFun = fun({K,_V}, Acc) -> 
 		      [K | Acc]
@@ -949,8 +949,8 @@ scanNoStartOrEnd_test() ->
     Opts=[{fold_method, streaming},
 	  {start_inclusive, false},
 	  {end_inclusive, false},
-	  {first_key, <<"key001">>},
-	  {last_key,   <<"key100">>}],
+	  {start_key, <<"key001">>},
+	  {end_key,   <<"key100">>}],
 
     FoldFun = fun({K,_V}, Acc) -> 
 		      [K | Acc]


### PR DESCRIPTION
…change was requested during dev of the eleveldb branch, but breaks riak_kv test code (and probably others) that still references start_key/end_key, and also creates inconsistent naming convention wrt other options that still reference start/end.  So we're changing it back.  Again.
