### PR TITLE
Moved ownership of extractor_ and range_filter_ from RangeScanOptions…

### DIFF
--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -494,9 +494,9 @@ RangeScanTask::RangeScanTask(ErlNifEnv * caller_env,
   range_filter_(0),
   extractor_(0)
 {
-    if (end_key) {
-        end_key_ = *end_key;
-    }
+    //------------------------------------------------------------
+    // Sanity checks
+    //------------------------------------------------------------
 
     if(options_.useRangeFilter_) {
         if(options_.encodingType_ == Encoding::MSGPACK)
@@ -504,6 +504,14 @@ RangeScanTask::RangeScanTask(ErlNifEnv * caller_env,
         else {
             ThrowRuntimeError("An invalid object encoding was specified");
         }
+    }
+
+    if(!sync_obj_) {
+        ThrowRuntimeError("Constructor was called with NULL SyncObject pointer");
+    }
+
+    if (end_key) {
+        end_key_ = *end_key;
     }
 
     sync_obj_->RefInc();

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -489,9 +489,7 @@ namespace eleveldb {
         Encoding::Type encodingType_;
         ERL_NIF_TERM rangeFilterSpec_;
         ErlNifEnv* env_;
-        ExpressionNode<bool>* range_filter_;
         bool useRangeFilter_;
-        Extractor* extractor_;
 
         RangeScanOptions() : 
             max_unacked_bytes(10 * 1024 * 1024), 
@@ -504,17 +502,10 @@ namespace eleveldb {
             verify_checksums(true), 
             encodingType_(Encoding::NONE),
             env_(0), 
-            range_filter_(0), 
-            useRangeFilter_(false), 
-            extractor_(0)
+            useRangeFilter_(false)
             { }
 
-        ~RangeScanOptions() {
-            if(range_filter_) {
-                delete range_filter_;
-                range_filter_ = 0;
-            }
-        };
+        ~RangeScanOptions() {};
 
         //------------------------------------------------------------
         // Sanity-check filter options
@@ -532,7 +523,6 @@ namespace eleveldb {
             if(useRangeFilter_) {
                 switch (encodingType_) {
                 case Encoding::MSGPACK:
-                    extractor_ = new ExtractorMsgpack();
                     break;
                 case Encoding::NONE:
                     ThrowRuntimeError("No object encoding was specified");
@@ -629,6 +619,8 @@ namespace eleveldb {
         std::string end_key_;
         bool has_end_key_;
         SyncObject * sync_obj_;
+        ExpressionNode<bool>* range_filter_;
+        Extractor* extractor_;
 
     };  // class RangeScanTask
 


### PR DESCRIPTION
… to RangeScanTask to simplify memory management and fix the memory leak introduced by extractor_ not being deleted in ~RangeScanOption()
