### PR TITLE
Sergey patch for compilation on El Capitan

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,12 +18,12 @@
        ]}.
 
 {port_env, [
-         %% Make sure to set -fPIC when compiling leveldb
-             {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
-             {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -std=c++0x"},
-             {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a c_src/system/lib/libsnappy.a -lstdc++"}
-             ]}.
+            %% Make sure to set -fPIC when compiling leveldb
+            {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
+            {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -std=c++11 -stdlib=libc++"}
+            {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include"},
+            {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a c_src/system/lib/libsnappy.a -lc++"}
+           ]}.
 
 {pre_hooks, [{'get-deps', "c_src/build_deps.sh get-deps"},
              {compile, "c_src/build_deps.sh"}]}.


### PR DESCRIPTION
This patch adds changes to the leveldb port_env to account for the C++11 changes in El Capitan. It fixes the problem of not being able to find the unordered_map, as it has moved.
