### PR TITLE
Bump the cuttlefish version to 2.0.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {erl_opts, [warnings_as_errors, debug_info]}.
 
 {deps, [
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.5"}}}
        ]}.
 
 {port_env, [


### PR DESCRIPTION
This is required to bump the lager version to 2.2.0
