### PR TITLE
Feature/new encoding

### DIFF
--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -11,6 +11,8 @@
 #include <arpa/inet.h>
 #include <inttypes.h>
 
+#define MSGPACK_MAGIC 2
+
 using namespace eleveldb;
 
 //=======================================================================
@@ -263,7 +265,7 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM oper1, ERL_NIF_TE
  *
  * New-style tuples should be of the form:
  *
- *    {field, "fieldname", type} or {const, val, type}
+ *    {field, "fieldname", type} or {const, val}
  *
  */
 DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throwIfInvalid)
@@ -292,6 +294,10 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
             if(op == eleveldb::filter::FIELD_OP)
                 fieldName = ErlUtil::getString(env, op_args[1]);
             
+            //------------------------------------------------------------
+            // Check 2-tuples
+            //------------------------------------------------------------
+
             if(arity == 2) {
                 
                 // If this is a constant expression, we defer to the field value
@@ -306,20 +312,33 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
                 if(op == eleveldb::filter::FIELD_OP)
                     return cTypeOf(fieldName);
 
+            //------------------------------------------------------------
+            // Check 3-tuples
+            //------------------------------------------------------------
+
             } else if(arity == 3) {
-                std::string type = ErlUtil::getAtom(env, op_args[2]);
 
-                // Store the type as-specified
-
-                expr_field_specs_[fieldName] = tsAtomToType(type, throwIfInvalid);
-
-                // Overwrite any inferences we may have made from parsing the data
-
-                field_types_[fieldName] = tsAtomToCtype(type, throwIfInvalid);
-
-                // And return the type
-
-                return tsAtomToCtype(type, throwIfInvalid);
+                // If this is a constant expression, and a type has
+                // been specified, we still defer to the field value
+                // against which we will be comparing it
+                
+                if(op == eleveldb::filter::CONST_OP) {
+                    return DataType::CONST;
+                } else {
+                    std::string type = ErlUtil::getAtom(env, op_args[2]);
+                    
+                    // Store the type as-specified
+                    
+                    expr_field_specs_[fieldName] = tsAtomToType(type, throwIfInvalid);
+                    
+                    // Overwrite any inferences we may have made from parsing the data
+                    
+                    field_types_[fieldName] = tsAtomToCtype(type, throwIfInvalid);
+                    
+                    // And return the type
+                    
+                    return tsAtomToCtype(type, throwIfInvalid);
+                }
             }
         }
 
@@ -341,9 +360,53 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
 bool Extractor::riakObjectContentsCanBeParsed(const char* data, size_t size)
 {
     const char* ptr = data;
-    ptr++;
+
+    //------------------------------------------------------------
+    // Skip the magic number and version
+    //------------------------------------------------------------
+
+    unsigned char magic    = (*ptr++);
     unsigned char vers     = (*ptr++);
-    return vers == 1;
+
+    if(!(magic == 53 && vers == 1))
+        return false;
+
+    //------------------------------------------------------------
+    // Skip the vclock len and vclock contents
+    //------------------------------------------------------------
+
+    unsigned int vClockLen = ntohl(*((unsigned int*)ptr));
+    ptr += 4;
+    ptr += vClockLen;
+
+    //------------------------------------------------------------
+    // Skip the sibling count
+    //------------------------------------------------------------
+
+    unsigned int sibCount =  ntohl(*((unsigned int*)ptr));
+    ptr += 4;
+
+    if(sibCount != 1)
+        return false;
+
+    //------------------------------------------------------------
+    // Now we are on to the first (and only) sibling.  Skip the length of
+    // the data contents for this sibling
+    //------------------------------------------------------------
+
+    ptr += 4;
+
+    //------------------------------------------------------------
+    // The next byte should now be the msgpack magic number (2).
+    // Check that it is
+    //------------------------------------------------------------
+
+    unsigned char encMagic = (*ptr++);
+
+    if(encMagic != MSGPACK_MAGIC)
+        return false;
+
+    return true;
 }
 
 /**.......................................................................
@@ -359,11 +422,11 @@ void Extractor::getToRiakObjectContents(const char* data, size_t size,
     // Skip the magic number and version
     //------------------------------------------------------------
 
-    ptr++;
+    unsigned char magic    = (*ptr++);
     unsigned char vers     = (*ptr++);
 
-    if(vers != 1)
-        ThrowRuntimeError("Riak object contents can only be inspected for v1 encoding");
+    if(!(magic == 53 && vers == 1))
+        ThrowRuntimeError("Riak object contents can only be inspected for magic = 53 and v1 encoding");
 
     //------------------------------------------------------------
     // Skip the vclock len and vclock contents
@@ -392,13 +455,23 @@ void Extractor::getToRiakObjectContents(const char* data, size_t size,
     ptr += 4;
 
     //------------------------------------------------------------
+    // The next byte should now be the msgpack magic number (2).
+    // Check that it is
+    //------------------------------------------------------------
+
+    unsigned char encMagic = (*ptr++);
+
+    if(encMagic != MSGPACK_MAGIC)
+        ThrowRuntimeError("This is not msgpack-encoded data");
+
+    //------------------------------------------------------------
     // Set the passed ptr pointing to the start of the contents for this
     // object, and set the returned length to be just the length of the
     // contents
     //------------------------------------------------------------
 
-    *contentsPtr = ptr;
-    contentsSize = valLen;
+    *contentsPtr  = ptr;
+     contentsSize = valLen;
 }
 
 //=======================================================================

--- a/c_src/filter.h
+++ b/c_src/filter.h
@@ -579,7 +579,7 @@ struct FieldValue<unsigned char*>: public ExpressionNode<unsigned char*> {
     size_t size_;
 
     FieldValue(const std::string fieldName, DataType::Type type) : 
-        ExpressionNode<unsigned char*>(type), field_(fieldName), has_val_(false) {}
+    ExpressionNode<unsigned char*>(type), field_(fieldName), has_val_(false), value_(0), size_(0) {}
 
     inline virtual bool has_value() const {
         return has_val_;


### PR DESCRIPTION
Per group discussion last Friday it was decided to change the riak_object content encoding format for TS, from:

<<EncBin/binary>>

to

<<?ENC_MAGIC/integer, EncBin/binary>>

This branch implements that encoding change in eleveldb, and a couple additional fixes along the way.  Changes are:

1) The encoding change necessitates a change in the way that eleveldb decodes the resulting binary.  This is the purpose of the changes to Extractor:getToRiakObjectContents() and Extractor:riakObjectContentsCanBeParsed(), and the addition of MSGPACK_MAGIC define to indicate that the encoding is msgpack.

2) unit-testing code sut.erl was modified to test these changes

3) I have also taken the opportunity to add a check for the magic number (53) at the head of the encoded riak object.  We were previously only checking the version, but should really be checking both numbers.

4) The change to Extractor::cTypeOf() is an additional protection against mis-use of the filtering API documented here: https://docs.google.com/document/d/1PNaiiBP-28Szljpi5owLMb2jKXOGpepOrsFQIbF4QcU/edit#heading=h.qb0fnpizuhxh.  Field values are specified with a type, like: {field, <<"f1">>, integer}, but constants shouldn't contain a type, which could conflict with the field specification, ie,they should be specified like {const, 2} instead of {const, 2, float}.  The previous code assumed that if arity == 3, the tuple was a field specification.  The modified code now checks if a 3-tuple is an invalid const specification, and quietly ignores ignores the type if it is.

5) Lastly, I noticed that some members of ExpressionNode<unsigned char*>(type) weren't initialized in the constructor.  This has produced no errors in testing, because has_val_ is always checked before value_ is ever accessed, but needed to be fixed nonetheless.
