### PR TITLE
Propagated recent SQL changes that apparently led to unadvertised cha…

### DIFF
--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -75,12 +75,36 @@ DataType::Type Extractor::tsAtomToType(std::string tsAtom, bool throwIfInvalid)
 {
     DataType::Type type = DataType::UNKNOWN;
 
-    if(tsAtom == "binary") {
+    // Used to be 'binary', now it's 'varchar'
+
+    if(tsAtom == "varchar") {
         type = DataType::BIN;
+
+        // But someone will probably still try to use 'binary' somewhere!
+
+    } else if(tsAtom == "binary") {
+        type = DataType::BIN;
+
+        // Used to be 'integer', now it's 'sint64'
+
+    } else if(tsAtom == "sint64") {
+        type = DataType::INT64;
+
+        // But someone will probably still try to use 'integer' somewhere!
+
     } else if(tsAtom == "integer") {
         type = DataType::INT64;
+
+        // Used to be 'float', now it's 'double'
+
+    } else if(tsAtom == "double") {
+        type = DataType::DOUBLE;
+
+        // But someone will probably still try to use 'float' somewhere!
+
     } else if(tsAtom == "float") {
         type = DataType::DOUBLE;
+
     } else if(tsAtom == "boolean") {
         type = DataType::BOOL;
     } else if(tsAtom == "timestamp") {

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -559,6 +559,20 @@ intOps_test() ->
     Res.
 
 %%------------------------------------------------------------
+%% Test sint64 operations, because now that's what we're calling integers
+%%------------------------------------------------------------
+
+sint64Ops_test() ->
+    io:format("sint64Ops_test~n"),
+    F = <<"f1">>,
+    Val = 3,
+    PutFn = fun putKeyNormalOps/1,
+    EvalFn = fun defaultEvalFn/1,
+    Res = allOps({F, {Val}, sint64, PutFn, EvalFn}),
+    ?assert(Res),
+    Res.
+
+%%------------------------------------------------------------
 %% Test binary operations
 %%------------------------------------------------------------
 
@@ -573,6 +587,21 @@ binaryOps_test() ->
     Res.
 
 %%------------------------------------------------------------
+%% Test varchar operations, because that's what were now calling
+%% binary
+%%------------------------------------------------------------
+
+varcharOps_test() ->
+    io:format("varcharOps_test~n"),
+    F = <<"f2">>,
+    Val = <<"test3">>,
+    PutFn = fun putKeyNormalOps/1,
+    EvalFn = fun defaultEvalFn/1,
+    Res = eqOpsOnly({F, {Val}, varchar, PutFn, EvalFn}) and (anyCompOps({F, {Val}, varchar, PutFn, EvalFn}) == false),
+    ?assert(Res),
+    Res.
+
+%%------------------------------------------------------------
 %% Test float operations
 %%------------------------------------------------------------
 
@@ -583,6 +612,21 @@ floatOps_test() ->
     PutFn = fun putKeyNormalOps/1,
     EvalFn = fun defaultEvalFn/1,
     Res = allOps({F, {Val}, float, PutFn, EvalFn}),
+    ?assert(Res),
+    Res.
+
+%%------------------------------------------------------------
+%% Test double operations, because that's what we're now calling
+%% 'float'
+%%------------------------------------------------------------
+
+doubleOps_test() ->
+    io:format("doubleOps_test~n"),
+    F = <<"f3">>,
+    Val = 3.0,
+    PutFn = fun putKeyNormalOps/1,
+    EvalFn = fun defaultEvalFn/1,
+    Res = allOps({F, {Val}, double, PutFn, EvalFn}),
     ?assert(Res),
     Res.
 
@@ -620,7 +664,7 @@ anyOps_test() ->
 %%------------------------------------------------------------
 
 normalOpsTests() ->
-    intOps_test() and binaryOps_test() and boolOps_test() and floatOps_test() and anyOps_test() and timestampOps_test().
+    intOps_test() and sint64Ops_test() and binaryOps_test() and varcharOps_test() and boolOps_test() and floatOps_test() and doubleOps_test() and anyOps_test() and timestampOps_test().
 
 %%=======================================================================
 %% Test AND + OR comparators


### PR DESCRIPTION
…nges to the elevledb interface ('integer' -> 'sint64', 'float' -> 'double', 'binary' -> 'varchar')

It was decided that fundamental datatypes (ints and floats) would be renamed at the SQL interface.  An unadvertised side effect of this change is that all the type names changed in the erlang-eleveldb interface too, which breaks all the C++ filtering code.  This PR includes support for the changes that were apparently made:

what used to be called 'binary' is now called 'varchar'
what used to be called 'float' is now called 'double'
what used to be called 'integer' is now called 'sint64'

I've modified the code to support the new naming conventions, and have modified the unit tests (sut.erl) to test the new naming conventions.
