### PR TITLE
Feature/bugfix filtercopy

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -551,11 +551,17 @@ ERL_NIF_TERM parse_streaming_option(ErlNifEnv* env, ERL_NIF_TERM item,
 
         } else if (option[0] == eleveldb::ATOM_RANGE_FILTER) {
 
-	    // Store the rangefilter spec and environment to parse later
+            //------------------------------------------------------------
+            // For the filter terms, opts is used merely as a
+            // convenience container.  The filter will be parsed in
+            // RangeScanTask constructor before these terms go out of
+            // scope of the NIF, so we do not need to safe copy them
+            // here
+            //------------------------------------------------------------
 
-	    opts.useRangeFilter_  = true;
-            opts.rangeFilterSpec_ = option[1];
+            opts.useRangeFilter_  = true;
             opts.env_             = env;
+            opts.rangeFilterSpec_ = option[1];
         }
     }
 

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -130,9 +130,8 @@ DataType::Type Extractor::cTypeOf(std::string fieldName)
     // If the field wasn't found, we don't know what type this field is
     //------------------------------------------------------------
 
-    if(field_types_.find(fieldName) == field_types_.end()) {
+    if(field_types_.find(fieldName) == field_types_.end())
         return DataType::UNKNOWN;
-    }
 
     //------------------------------------------------------------
     // Else retrieve the stored type, potentially converting to a
@@ -298,8 +297,7 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
 
             if(!(op == eleveldb::filter::FIELD_OP || op == eleveldb::filter::CONST_OP)) {
                 if(throwIfInvalid)
-                    ThrowRuntimeError("Invalid operand type: '" << op 
-                                      << "' while parsing expression: '" 
+                    ThrowRuntimeError("Invalid operand type: '" << op << "' while parsing expression: '" 
                                       << ErlUtil::formatTerm(env, tuple) << "'");
             }
 
@@ -315,16 +313,14 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
                 // If this is a constant expression, we defer to the field value
                 // against which we will be comparing it
                 
-                if(op == eleveldb::filter::CONST_OP) {
+                if(op == eleveldb::filter::CONST_OP)
                     return DataType::CONST;
-                }
                 
                 // Else a field -- parse the field name, and return the type of
                 // the datum for that field
                 
-                if(op == eleveldb::filter::FIELD_OP) {
+                if(op == eleveldb::filter::FIELD_OP)
                     return cTypeOf(fieldName);
-                }
 
             //------------------------------------------------------------
             // Check 3-tuples
@@ -348,13 +344,14 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
                     // Overwrite any inferences we may have made from parsing the data
                     
                     DataType::Type specType = tsAtomToCtype(type, throwIfInvalid);
-                    expr_fields_[fieldName] = specType;
-
-                    // NB: Now that we are not inferring data types
-                    // from the decoded data, set field_types_ to the
-                    // explicit type, for use during data extraction
 
                     field_types_[fieldName] = specType;
+
+                    // NB: Now that we are not inferring data types
+                    // from the decoded data, set expr_fields_ to the
+                    // explicit type, for use during data extraction
+
+                    expr_fields_[fieldName] = specType;
 
                     // And return the type
                     
@@ -364,8 +361,7 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
         }
 
         if(throwIfInvalid)
-            ThrowRuntimeError("Invalid field or const specifier: " 
-                              << ErlUtil::formatTerm(env, tuple));
+            ThrowRuntimeError("Invalid field or const specifier: " << ErlUtil::formatTerm(env, tuple));
 
     } catch(std::runtime_error& err) {
         if(throwIfInvalid)

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -130,8 +130,9 @@ DataType::Type Extractor::cTypeOf(std::string fieldName)
     // If the field wasn't found, we don't know what type this field is
     //------------------------------------------------------------
 
-    if(field_types_.find(fieldName) == field_types_.end())
+    if(field_types_.find(fieldName) == field_types_.end()) {
         return DataType::UNKNOWN;
+    }
 
     //------------------------------------------------------------
     // Else retrieve the stored type, potentially converting to a
@@ -297,7 +298,8 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
 
             if(!(op == eleveldb::filter::FIELD_OP || op == eleveldb::filter::CONST_OP)) {
                 if(throwIfInvalid)
-                    ThrowRuntimeError("Invalid operand type: '" << op << "' while parsing expression: '" 
+                    ThrowRuntimeError("Invalid operand type: '" << op 
+                                      << "' while parsing expression: '" 
                                       << ErlUtil::formatTerm(env, tuple) << "'");
             }
 
@@ -313,14 +315,16 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
                 // If this is a constant expression, we defer to the field value
                 // against which we will be comparing it
                 
-                if(op == eleveldb::filter::CONST_OP)
+                if(op == eleveldb::filter::CONST_OP) {
                     return DataType::CONST;
+                }
                 
                 // Else a field -- parse the field name, and return the type of
                 // the datum for that field
                 
-                if(op == eleveldb::filter::FIELD_OP)
+                if(op == eleveldb::filter::FIELD_OP) {
                     return cTypeOf(fieldName);
+                }
 
             //------------------------------------------------------------
             // Check 3-tuples
@@ -343,8 +347,15 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
                     
                     // Overwrite any inferences we may have made from parsing the data
                     
-                    field_types_[fieldName] = tsAtomToCtype(type, throwIfInvalid);
-                    
+                    DataType::Type specType = tsAtomToCtype(type, throwIfInvalid);
+                    expr_fields_[fieldName] = specType;
+
+                    // NB: Now that we are not inferring data types
+                    // from the decoded data, set field_types_ to the
+                    // explicit type, for use during data extraction
+
+                    field_types_[fieldName] = specType;
+
                     // And return the type
                     
                     return tsAtomToCtype(type, throwIfInvalid);
@@ -353,7 +364,8 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
         }
 
         if(throwIfInvalid)
-            ThrowRuntimeError("Invalid field or const specifier: " << ErlUtil::formatTerm(env, tuple));
+            ThrowRuntimeError("Invalid field or const specifier: " 
+                              << ErlUtil::formatTerm(env, tuple));
 
     } catch(std::runtime_error& err) {
         if(throwIfInvalid)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -22,8 +22,6 @@
 
 #include <syslog.h>
 
-#define EMLTEST 
-
 #ifndef __ELEVELDB_DETAIL_HPP
     #include "detail.hpp"
 #endif

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -22,6 +22,8 @@
 
 #include <syslog.h>
 
+#define EMLTEST 
+
 #ifndef __ELEVELDB_DETAIL_HPP
     #include "detail.hpp"
 #endif
@@ -785,6 +787,35 @@ RangeScanTask::RangeScanTask(ErlNifEnv * caller_env,
         else {
             ThrowRuntimeError("An invalid object encoding was specified");
         }
+
+        //------------------------------------------------------------
+        // Since the data types are now passed with the filter, we no
+        // longer need to wait to decode some data to determine them,
+        // so parse the filter up-front.  Note that to use the code
+        // as-is, we need to set extractor_->typesParsed_ to true as
+        // if we had parsed the datatypes
+        //------------------------------------------------------------
+
+        bool throwIfBadFilter = true;
+        
+        //------------------------------------------------------------
+        // The code allows for individual filter conditions to be bad,
+        // i.e., conditions that reference fields that don't exist, or
+        // compare field values to constants of the wrong type.
+        //
+        // If throwIfBadFilter is set to true, these are treated as fatal
+        // errors, halting execution of the loop.
+        // 
+        // If on the other hand, throwIfBadFilter is set to false, bad
+        // filter conditions are ignored (always true), and the rest of
+        // the filter will be evaluated anyway
+        //------------------------------------------------------------
+        
+        extractor_->typesParsed_ = true;
+
+        range_filter_ = parse_range_filter_opts(options_.env_, 
+                                                options_.rangeFilterSpec_, 
+                                                *(extractor_), throwIfBadFilter);
     }
     
     if(!sync_obj_) {
@@ -898,21 +929,6 @@ work_result RangeScanTask::operator()()
     size_t out_offset = 0;
     size_t num_read   = 0;
 
-    //------------------------------------------------------------ 
-    // The code allows for individual filter conditions to be bad,
-    // i.e., conditions that reference fields that don't exist, or
-    // compare field values to constants of the wrong type.
-    //
-    // If throwIfBadFilter is set to true, these are treated as fatal
-    // errors, halting execution of the loop.
-    // 
-    // If on the other hand, throwIfBadFilter is set to false, bad
-    // filter conditions are ignored (always true), and the rest of
-    // the filter will be evaluated anyway
-    //------------------------------------------------------------
-
-    bool throwIfBadFilter = true;
-
     //------------------------------------------------------------
     // Skip if not including first key and first key exists
     //------------------------------------------------------------
@@ -958,8 +974,10 @@ work_result RangeScanTask::operator()()
 
 	//------------------------------------------------------------
 	// Else keep going; shove the next entry in the batch, but
-	// only if it passes any user-specified filter
-	// ------------------------------------------------------------
+	// only if it passes any user-specified filter.  We default to
+	// filter_passed = true, in case we are not using a filter,
+	// which will cause all keys to be returned
+	//------------------------------------------------------------
 
         leveldb::Slice key   = iter->key();
         leveldb::Slice value = iter->value();
@@ -972,100 +990,54 @@ work_result RangeScanTask::operator()()
 
         if(options_.useRangeFilter_) {
 
-	  try {
-
-	    //------------------------------------------------------------
-	    // If the filter has not yet been parsed, check the data
-	    // types of all fields in this key, then parse the filter,
-	    // so we know which templatized versions of the
-	    // ExpressionNodes to use.  If the data can't be decoded,
-	    // set filter_passed to false to ignore this key.
-	    // ------------------------------------------------------------
-
-	    if(!extractor_->typesParsed_) {
+            try {
 
                 //------------------------------------------------------------
-                // Only attempt to parse the data if it is correctly
-                // formatted, otherwise we would throw an error. 
+                // Now extract relevant fields of this object prior to
+                // evaluating the filter. We check if the range filter is
+                // non-NULL, because passing a filter specification that
+                // refers to invalid fields can result in a NULL
+                // expression tree.  In this case, we don't bother
+                // extracting the data or evaluating the filter
                 //------------------------------------------------------------
 
-                if(extractor_->riakObjectContentsCanBeParsed(value.data(), value.size())) {
-             
-                    extractor_->parseRiakObjectTypes(value.data(), value.size());
+                if(range_filter_) {
 
                     //------------------------------------------------------------
-                    // Parse the filter here.  We trap the throw error
-                    // here and rethrow, so we can report an
-                    // informative error that the filter was malformed
+                    // Also check if the key can be parsed.  If TS-encoded
+                    // data and non-TS encoded data are interleaved, this
+                    // causes us to ignore the non-TS-encoded data
                     //------------------------------------------------------------
+                    
+                    if(extractor_->riakObjectContentsCanBeParsed(value.data(), value.size())) {
+                        
+                        extractor_->extractRiakObject(value.data(), value.size(), range_filter_);
+                        
+                        //------------------------------------------------------------
+                        // Now evaluate the filter, but only if we have a valid filter
+                        //------------------------------------------------------------
+                        
+                        filter_passed = range_filter_->evaluate();
 
-                    try {
-                        range_filter_ = 
-                            parse_range_filter_opts(options_.env_, 
-                                                    options_.rangeFilterSpec_, *(extractor_),
-                                                    throwIfBadFilter);
-                    } catch(std::runtime_error& err) {
-                        std::ostringstream os;
-                        os << err.what() << std::endl << "While processing filter: " 
-                           << ErlUtil::formatTerm(options_.env_, options_.rangeFilterSpec_);
-
-                        ThrowRuntimeError(os.str());
+                    } else {
+                        filter_passed = false;
                     }
-
-                    //------------------------------------------------------------
-                    // If this value can't be parsed, set
-                    // filter_passed to false, which will ignore the
-                    // key
-                    //------------------------------------------------------------
-
-                } else {
-                    filter_passed = false;
                 }
-            }
-
-	    //------------------------------------------------------------
-	    // Now extract relevant fields of this object prior to
-	    // evaluating the filter. We check if the range filter is
-	    // non-NULL, because passing a filter specification that
-	    // refers to invalid fields can result in a NULL
-	    // expression tree.  In this case, we don't bother
-	    // extracting the data or evaluating the filter
-	    //------------------------------------------------------------
-
-            if(range_filter_) {
 
                 //------------------------------------------------------------
-                // Also check if the key can be parsed.  If TS-encoded
-                // data and non-TS encoded data are interleaved, this
-                // causes us to ignore the non-TS-encoded data
+                // Trap errors thrown during filter parsing or value
+                // extraction, and propagate to erlang
                 //------------------------------------------------------------
-
-                if(extractor_->riakObjectContentsCanBeParsed(value.data(), value.size())) {
-
-                    extractor_->extractRiakObject(value.data(), value.size(), range_filter_);
-            
-                    //------------------------------------------------------------
-                    // Now evaluate the filter, but only if we have a valid filter
-                    //------------------------------------------------------------
-            
-                    filter_passed = range_filter_->evaluate();
-                }
+                
+            } catch(std::runtime_error& err) {
+                std::ostringstream os;
+                os << err.what() << std::endl << "While processing key: " 
+                   << ErlUtil::formatBinary((unsigned char*)key.data(), key.size());
+                
+                sendMsg(msg_env, ATOM_STREAMING_ERROR, pid, os.str());
+                return work_result(local_env(), ATOM_ERROR, ATOM_STREAMING_ERROR);
             }
-
-            //------------------------------------------------------------
-            // Trap errors thrown during filter parsing or value
-            // extraction, and propagate to erlang
-            //------------------------------------------------------------
-
-	  } catch(std::runtime_error& err) {
-              std::ostringstream os;
-              os << err.what() << std::endl << "While processing key: " 
-                 << ErlUtil::formatBinary((unsigned char*)key.data(), key.size());
-
-              sendMsg(msg_env, ATOM_STREAMING_ERROR, pid, os.str());
-              return work_result(local_env(), ATOM_ERROR, ATOM_STREAMING_ERROR);
-	  }
-
+            
         }
 
         if (filter_passed) {


### PR DESCRIPTION
…reaming_start.  This avoids the issue of having to copy the erlang filter specification for later evaluation

**Context:**
When this code was originally developed, no type information was passed down from erlang about the fields used in the filtering.  This type information is required to build the expression tree that evaluates the filter in C++, which meant that the filter specification couldn't be parsed until the first data record was read (from which I could infer the datatype information).  In short, the original erlang filter spec was stored and parsed later.  

It was not, however, safely copied using enif_make_copy(), etc., and the code could therefore segfault if erlang garbage-collected the terms before the filter was parsed in the worker thread.

Since then, we have changed the erlang code to pass type information about the fields, so the filter can now be parsed during setup while the original erlang terms are still in scope.  This is the essence of this PR -- I've removed the delayed filter parsing from the worker thread in workitems.cc to the originating NIF call in eleveldb.cc.

Changes are:
1. added some notes to eleveldb.cc.  The code has not changed
2. extractor.cc:  The only substantive change is line 354, which sets expr_fields_[field] to whatever the filter specification says it is.  This is a map that originally contained the datatypes inferred from parsing the encoded data, which is later used in the data extraction (cf ExtractorMsgpack::extract() ) to compare against the datatypes used to build the filter.  Overwriting it here lets me use the rest of the extractor code unmodified.
3. workitems.cc: Two substantive changes:  
   - I've modified RangeScanTask to parse the filter in the constructor.  This constructor is called in eleveldb.cc:streaming_start while the relevant erlang terms are still in scope, thus eliminating the need to copy them.
   - I've removed the filter parsing from RangeScanTask::operator().  This was previously a needlessly complicated two-step process where I parsed the first data record to get the type information, then parsed the filter.  This code is no longer needed and has been removed
4. sut.erl: unit tests had to be changed because we've changed the behavior of the C++ code to throw errors on unsupported operators (e.g., '< ' used with binaries) rather than quietly return an empty key list.  This means that the corresponding null tests in sut.erl have to trap the error rather then check for an empty return list.
