### PR TITLE
Perf/test release candidate

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -72,6 +72,7 @@ static ErlNifFunc nif_funcs[] =
 
     {"async_open", 3, eleveldb::async_open},
     {"async_write", 4, eleveldb::async_write},
+    {"sync_write", 4, eleveldb::sync_write},
     {"async_get", 4, eleveldb::async_get},
 
     {"async_iterator", 3, eleveldb::async_iterator},
@@ -751,6 +752,61 @@ async_write(
     eleveldb::WorkTask* work_item = new eleveldb::WriteTask(env, caller_ref,
                                                             db_ptr.get(), batch, opts);
     return submit_to_thread_queue(work_item, env, caller_ref);
+}
+
+ERL_NIF_TERM
+sync_write(
+    ErlNifEnv* env,
+    int argc,
+    const ERL_NIF_TERM argv[])
+{
+    const ERL_NIF_TERM& caller_ref = argv[0];
+    const ERL_NIF_TERM& handle_ref = argv[1];
+    const ERL_NIF_TERM& action_ref = argv[2];
+    const ERL_NIF_TERM& opts_ref   = argv[3];
+
+    ReferencePtr<DbObject> db_ptr;
+
+    db_ptr.assign(DbObject::RetrieveDbObject(env, handle_ref));
+
+    if(NULL==db_ptr.get()
+       || !enif_is_list(env, action_ref)
+       || !enif_is_list(env, opts_ref))
+    {
+        return enif_make_badarg(env);
+    }
+
+    // is this even possible?
+    if(NULL == db_ptr->m_Db)
+        return send_reply(env, caller_ref, error_einval(env));
+
+    // Construct a write batch:
+    leveldb::WriteBatch* batch = new leveldb::WriteBatch;
+
+    // Seed the batch's data:
+    ERL_NIF_TERM result = fold(env, argv[2], write_batch_item, *batch);
+    if(eleveldb::ATOM_OK != result)
+    {
+        return send_reply(env, caller_ref,
+                          enif_make_tuple3(env, eleveldb::ATOM_ERROR, caller_ref,
+                                           enif_make_tuple2(env, eleveldb::ATOM_BAD_WRITE_ACTION,
+                                                            result)));
+    }   // if
+
+    leveldb::WriteOptions* opts = new leveldb::WriteOptions;
+    fold(env, argv[3], parse_write_option, *opts);
+
+    eleveldb::WorkTask* work_item = new eleveldb::WriteTask(env, caller_ref,
+                                                            db_ptr.get(), batch, opts);
+    (*work_item)();
+
+    //------------------------------------------------------------
+    // Free the allocated object.  Also frees the WriteBatch and WriteOptions objects
+    //------------------------------------------------------------
+
+    delete work_item;
+
+    return eleveldb::ATOM_OK;
 }
 
 ERL_NIF_TERM

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -798,7 +798,7 @@ sync_write(
 
     eleveldb::WorkTask* work_item = new eleveldb::WriteTask(env, caller_ref,
                                                             db_ptr.get(), batch, opts);
-    (*work_item)();
+    work_result status = (*work_item)();
 
     //------------------------------------------------------------
     // Free the allocated object.  Also frees the WriteBatch and WriteOptions objects
@@ -806,7 +806,7 @@ sync_write(
 
     delete work_item;
 
-    return eleveldb::ATOM_OK;
+    return status.result();
 }
 
 ERL_NIF_TERM

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -43,6 +43,7 @@ namespace eleveldb {
 
 ERL_NIF_TERM async_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM async_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM sync_write(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM async_get(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM async_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM async_destroy(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -26,6 +26,7 @@
          get/3,
          put/4,
          async_put/5,
+         sync_put/5,
          delete/3,
          write/3,
          fold/4,
@@ -228,6 +229,16 @@ async_put(Ref, Context, Key, Value, Opts) ->
 
 -spec async_write(reference(), db_ref(), write_actions(), write_options()) -> ok.
 async_write(_CallerRef, _Ref, _Updates, _Opts) ->
+    erlang:nif_error({error, not_loaded}).
+
+-spec sync_put(db_ref(), reference(), binary(), binary(), write_options()) -> ok.
+sync_put(Ref, Context, Key, Value, Opts) ->
+    Updates = [{put, Key, Value}],
+    sync_write(Context, Ref, Updates, Opts),
+    ok.
+
+-spec sync_write(reference(), db_ref(), write_actions(), write_options()) -> ok.
+sync_write(_CallerRef, _Ref, _Updates, _Opts) ->
     erlang:nif_error({error, not_loaded}).
 
 -spec async_iterator(reference(), db_ref(), itr_options()) -> ok.

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -231,12 +231,12 @@ async_put(Ref, Context, Key, Value, Opts) ->
 async_write(_CallerRef, _Ref, _Updates, _Opts) ->
     erlang:nif_error({error, not_loaded}).
 
--spec sync_put(db_ref(), reference(), binary(), binary(), write_options()) -> ok.
+-spec sync_put(db_ref(), reference(), binary(), binary(), write_options()) -> ok | {error, any()}.
 sync_put(Ref, Context, Key, Value, Opts) ->
     Updates = [{put, Key, Value}],
     sync_write(Context, Ref, Updates, Opts).
 
--spec sync_write(reference(), db_ref(), write_actions(), write_options()) -> ok.
+-spec sync_write(reference(), db_ref(), write_actions(), write_options()) -> ok | {error, any()}.
 sync_write(_CallerRef, _Ref, _Updates, _Opts) ->
     erlang:nif_error({error, not_loaded}).
 

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -234,8 +234,7 @@ async_write(_CallerRef, _Ref, _Updates, _Opts) ->
 -spec sync_put(db_ref(), reference(), binary(), binary(), write_options()) -> ok.
 sync_put(Ref, Context, Key, Value, Opts) ->
     Updates = [{put, Key, Value}],
-    sync_write(Context, Ref, Updates, Opts),
-    ok.
+    sync_write(Context, Ref, Updates, Opts).
 
 -spec sync_write(reference(), db_ref(), write_actions(), write_options()) -> ok.
 sync_write(_CallerRef, _Ref, _Updates, _Opts) ->


### PR DESCRIPTION
Added sync_put/sync_write functions to eleveldb to do the work of the leveldb write in the NIF call itself (rather than async_put, which expects the caller to block on an asynchronous reply, or put, which calls async_write and blocks in eleveldb for the reply).  

This is half of a last-minute performance optimization for TS1.0 (the other half is in riak_kv, where riak_kv_vnode:handle_command calls sync_put instead of async_put for the TS W1C path).

This could be improved by avoiding the object creation altogether and performing the leveldb write directly in the NIF code instead of using the WriteTask infrastructure, but I wanted to make as few untested deviations from async_put as possible, given the timeframe.

And it is understood that use of this function is very risky, since it provides no guarantees to the erlang scheduler about execution time.  The plan is to incorporate MvM's changes to check what leveldb is about to do before using a synchronous put, for TS1.1
