### PR TITLE
Fixed potential memory leak on error in RangeScanTask::operator()

### DIFF
--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -1035,6 +1035,12 @@ work_result RangeScanTask::operator()()
                    << ErlUtil::formatBinary((unsigned char*)key.data(), key.size());
                 
                 sendMsg(msg_env, ATOM_STREAMING_ERROR, pid, os.str());
+
+                if(binaryAllocated)
+                    enif_release_binary(&bin);
+
+                enif_free_env(msg_env);
+
                 return work_result(local_env(), ATOM_ERROR, ATOM_STREAMING_ERROR);
             }
             


### PR DESCRIPTION
catch clause on error didn't free allocated msg_env (or binary for returned values, for that matter).  This PR adds cleanup of these variables on exceptional return.
