### PR TITLE
add fold() for options within eleveldb_repair().

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -1126,10 +1126,12 @@ eleveldb_repair(
     const ERL_NIF_TERM argv[])
 {
     char name[4096];
-    if (enif_get_string(env, argv[0], name, sizeof(name), ERL_NIF_LATIN1))
+    if (enif_get_string(env, argv[0], name, sizeof(name), ERL_NIF_LATIN1)
+        && enif_is_list(env, argv[1]))
     {
         // Parse out the options
         leveldb::Options opts;
+        fold(env, argv[1], parse_open_option, opts);
 
         leveldb::Status status = leveldb::RepairDB(name, opts);
         if (!status.ok())


### PR DESCRIPTION
Original code for eleveldb_repair() lost a line for converting Erlang options into the eleveldb::Options structure.  The defaults for eleveldb::Options are sufficient for normal database / Riak vnodes, but not for Basho's leveldb tiered storage feature.  This branch corrects the issue.

More details:

https://github.com/basho/leveldb/wiki/mv-fix-repair-options
