### PR TITLE
Add dialyzer spec for iterator_move prefetch_stop argument..

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -120,7 +120,7 @@ init() ->
                           {delete, Key::binary()} |
                           clear].
 
--type iterator_action() :: first | last | next | prev | prefetch | binary().
+-type iterator_action() :: first | last | next | prev | prefetch | prefetch_stop | binary().
 
 -opaque db_ref() :: binary().
 


### PR DESCRIPTION
Resolves a dialyzer failure for basho/riak_core#830, needed on 2.0.18 - can re-open PR against a different branch if it helps.
