### PR TITLE
Type conversion of bool to ??? too tricky with Solaris CAS.

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -861,11 +861,11 @@ async_iterator_move(
         // using compare_and_swap has a hardware locking "set only if still in same state as before"
         //  (this is an absolute must since worker thread could change to false if
         //   hits end of key space and its execution overlaps this block's execution)
-	int cas_temp((eleveldb::MoveTask::PREFETCH_STOP != action )  // needed for Solaris CAS
-		     && itr_ptr->m_Iter->Valid());
+        int cas_temp((eleveldb::MoveTask::PREFETCH_STOP != action )  // needed for Solaris CAS
+                     && itr_ptr->m_Iter->Valid());
         leveldb::compare_and_swap(&itr_ptr->m_Iter->m_PrefetchStarted,
                                   prefetch_state,
-				  cas_temp);
+                                  cas_temp);
     }   // else if
 
     // case #3

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -218,7 +218,8 @@ public:
     leveldb::Iterator * m_Iterator;
     volatile uint32_t m_HandoffAtomic;        //!< matthew's atomic foreground/background prefetch flag.
     bool m_KeysOnly;                          //!< only return key values
-    volatile bool m_PrefetchStarted;          //!< true after first prefetch command
+    // m_PrefetchStarted must use uint32_t instead of bool for Solaris CAS operations
+    volatile uint32_t m_PrefetchStarted;          //!< true after first prefetch command
     leveldb::ReadOptions m_Options;           //!< local copy of ItrObject::options
     ERL_NIF_TERM itr_ref;                     //!< shared copy of ItrObject::itr_ref
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -307,7 +307,7 @@ MoveTask::DoWork()
         {
             // using compare_and_swap as a hardware locking "set to false"
             //  (a little heavy handed, but not executed often)
-            leveldb::compare_and_swap(&m_ItrWrap->m_PrefetchStarted, true, false);
+            leveldb::compare_and_swap(&m_ItrWrap->m_PrefetchStarted, (int)true, (int)false);
             return work_result(local_env(), ATOM_ERROR, ATOM_INVALID_ITERATOR);
         }   // else
 


### PR DESCRIPTION
A recent branch added atomic compare and set operations for the bool variable m_PrefetchStarted.  This did not compile on Solaris.  Solaris does have an 8-bit version of its compare set.  But I did not find a document that guaranteed bool would be 8-bits.  I could still use the 8-bit CAS, but would then have to assume all platforms were little endian.

Decided to take the safe and fast path.  Changed m_PrefetchStarted to uint32_t.  Then matched all the compare_and_swap() call parameters to match the existing compare_and_swap(volatile uint32_t *, int, int) function.

All platforms compile and test just fine now.
