### PR TITLE
Mv iter valid

### DIFF
--- a/BASHO_RELEASES
+++ b/BASHO_RELEASES
@@ -1,3 +1,9 @@
+github.com tag 2.0.22 - June 21, 2016
+-------------------------------------
+ - branch mv-iter-valid (PR 199): adjust recent code accessing iterator->Valid() where
+   underlying iterator could be deleted ... now cache Valid().
+ - eleveldb only, no leveldb changes
+
 github.com tag 2.0.21 - June 17, 2016
 -------------------------------------
  - update to leveldb 2.0.21 (correct hot threads for iterator hang)

--- a/BASHO_RELEASES
+++ b/BASHO_RELEASES
@@ -1,0 +1,5 @@
+github.com tag 2.0.21 - June 17, 2016
+-------------------------------------
+ - update to leveldb 2.0.21 (correct hot threads for iterator hang)
+ - temporary iterator debug code still in this release
+

--- a/README.md
+++ b/README.md
@@ -11,3 +11,31 @@ In summary, the "develop" branch contains the most recently reviewed
 engineering work.  The "master" branch contains the most recently
 released work, i.e. distributed as part of a Riak release.
 
+# Iterating Records
+
+## High-level Iterator Interface
+
+The interface that most clients of eleveldb should use when iterating over a set of records stored in leveldb is `fold`, since this fits nicely with the Erlang way of doing things.
+
+For those who need more control over the process of iterating over records, you can use direct iterator actions. Use them with great care.
+
+## Direct Iterator Actions
+
+### seek/next/prev
+
+- **seek:** Move iterator to a new position.
+
+- **next:** Move forward one position and return the value; do nothing else.
+
+- **prev:** Move backward one position and return the value; do nothing else.
+
+### prefetc/prefetch_stop
+
+- **prefetch:** Perform a `next` action and then start a parallel call for the subsequent `next` while Erlang processes the current `next`. The subsequent `prefetch` may return immediately with the value already retrieved.
+
+- **prefetch_stop:** Stop a sequence of `prefetch` calls. If there is a parallel `prefetch` pending, cancel it, since we are about to move the pointer.
+
+### Warning
+
+Either use `prefetch`/`prefetch_stop` or `next`/`prev`.  Do not intermix `prefetch` and `next`/`prev`.  You must `prefetch_stop` after one or more `prefetch` operations before using any of the other operations (`seek`, `next`, `prev`).
+

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.17"
+LEVELDB_VSN="2.0.18"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.21"
+LEVELDB_VSN=""
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.20"
+LEVELDB_VSN="2.0.21"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.18"
+LEVELDB_VSN="2.0.19"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.19"
+LEVELDB_VSN="2.0.20"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -1013,6 +1013,7 @@ async_iterator_close(
 
     if(NULL==itr_ptr.get() || 0!=itr_ptr->m_CloseRequested)
     {
+       leveldb::gPerfCounters->Inc(leveldb::ePerfDebug4);
        return enif_make_badarg(env);
     }
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -775,7 +775,8 @@ async_iterator_move(
     const ERL_NIF_TERM& action_or_target = argv[2];
     ERL_NIF_TERM ret_term;
 
-    bool submit_new_request(true), prefetch_state;
+    bool submit_new_request(true);
+    int prefetch_state;      // not bool for Solaris CAS
 
     ReferencePtr<ItrObject> itr_ptr;
 
@@ -860,10 +861,11 @@ async_iterator_move(
         // using compare_and_swap has a hardware locking "set only if still in same state as before"
         //  (this is an absolute must since worker thread could change to false if
         //   hits end of key space and its execution overlaps this block's execution)
+        int cas_temp((eleveldb::MoveTask::PREFETCH_STOP != action )  // needed for Solaris CAS
+                     && itr_ptr->m_Iter->Valid());
         leveldb::compare_and_swap(&itr_ptr->m_Iter->m_PrefetchStarted,
                                   prefetch_state,
-                                  (eleveldb::MoveTask::PREFETCH_STOP != action )
-                                  && itr_ptr->m_Iter->Valid());
+                                  cas_temp);
     }   // else if
 
     // case #3

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -393,7 +393,7 @@ LevelIteratorWrapper::LevelIteratorWrapper(
       m_HandoffAtomic(0), m_KeysOnly(KeysOnly), m_PrefetchStarted(false),
       m_Options(Options), itr_ref(itr_ref),
       m_IteratorStale(0), m_StillUse(true),
-      m_IteratorCreated(0), m_LastLogReport(0), m_MoveCount(0)
+      m_IteratorCreated(0), m_LastLogReport(0), m_MoveCount(0), m_IsValid(false)
 {
     struct timeval tv;
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -218,7 +218,8 @@ public:
     leveldb::Iterator * m_Iterator;
     volatile uint32_t m_HandoffAtomic;        //!< matthew's atomic foreground/background prefetch flag.
     bool m_KeysOnly;                          //!< only return key values
-    volatile bool m_PrefetchStarted;          //!< true after first prefetch command
+    // m_PrefetchStarted must use uint32_t instead of bool for Solaris CAS operations
+    volatile uint32_t m_PrefetchStarted;          //!< true after first prefetch command
     leveldb::ReadOptions m_Options;           //!< local copy of ItrObject::options
     ERL_NIF_TERM itr_ref;                     //!< shared copy of ItrObject::itr_ref
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -228,6 +228,11 @@ public:
     time_t m_IteratorStale;                   //!< time iterator should refresh
     bool m_StillUse;                          //!< true if no error or key end seen
 
+    // debug data for hung iteratos
+    time_t m_IteratorCreated;                 //!< time constructor called
+    time_t m_LastLogReport;                   //!< LOG message was last written
+    size_t m_MoveCount;                       //!< number of calls to MoveItem
+
     LevelIteratorWrapper(ItrObject * ItrPtr, bool KeysOnly,
                          leveldb::ReadOptions & Options, ERL_NIF_TERM itr_ref);
 
@@ -272,6 +277,9 @@ public:
         m_Options.snapshot = m_Snapshot;
         m_Iterator = m_DbPtr->m_Db->NewIterator(m_Options);
     }   // RebuildIterator
+
+    // hung iterator debug
+    void LogIterator();
 
 private:
     LevelIteratorWrapper(const LevelIteratorWrapper &);            // no copy

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -131,8 +131,10 @@ public:
 
     ~ReferencePtr()
     {
-        if (NULL!=t)
-            t->RefDec();
+        TargetT * temp_ptr(t);
+        t=NULL;
+        if (NULL!=temp_ptr)
+            temp_ptr->RefDec();
     }
 
     void assign(TargetT * _t)
@@ -233,6 +235,9 @@ public:
     time_t m_LastLogReport;                   //!< LOG message was last written
     size_t m_MoveCount;                       //!< number of calls to MoveItem
 
+    // read by Erlang thread, maintained by eleveldb MoveItem::DoWork
+    volatile bool m_IsValid;                  //!< iterator state after last operation
+
     LevelIteratorWrapper(ItrObject * ItrPtr, bool KeysOnly,
                          leveldb::ReadOptions & Options, ERL_NIF_TERM itr_ref);
 
@@ -242,9 +247,12 @@ public:
     }   // ~LevelIteratorWrapper
 
     leveldb::Iterator * get() {return(m_Iterator);};
-    leveldb::Iterator * operator->() {return(m_Iterator);};
 
-    bool Valid() {return(NULL!=m_Iterator && m_Iterator->Valid());};
+    volatile bool Valid() {return(m_IsValid);};
+    void SetValid(bool flag) {m_IsValid=flag;};
+
+    // warning, only valid with Valid() otherwise potential
+    //   segfault if iterator purged to fix AAE'ism
     leveldb::Slice key() {return(m_Iterator->key());};
     leveldb::Slice value() {return(m_Iterator->value());};
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -305,7 +305,9 @@ MoveTask::DoWork()
         }   // if
         else
         {
-            m_ItrWrap->m_PrefetchStarted=false;
+            // using compare_and_swap as a hardware locking "set to false"
+            //  (a little heavy handed, but not executed often)
+            leveldb::compare_and_swap(&m_ItrWrap->m_PrefetchStarted, true, false);
             return work_result(local_env(), ATOM_ERROR, ATOM_INVALID_ITERATOR);
         }   // else
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -230,7 +230,7 @@ MoveTask::DoWork()
         struct timeval tv;
 
         gettimeofday(&tv, NULL);
-        
+
         // 14400 is 4 hours in seconds ... 60*60*4
         if ((m_ItrWrap->m_LastLogReport + 14400) < tv.tv_sec && NULL!=m_ItrWrap->get())
         {
@@ -271,6 +271,9 @@ MoveTask::DoWork()
             break;
 
     }   // switch
+
+    // set state for Erlang side to read
+    m_ItrWrap->SetValid(itr->Valid());
 
     // Post processing before telling the world the results
     //  (while only one thread might be looking at objects)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -191,7 +191,7 @@ MoveTask::DoWork()
 
     itr=m_ItrWrap->get();
 
-
+    ++m_ItrWrap->m_MoveCount;
 //
 // race condition of prefetch clearing db iterator while
 //  async_iterator_move looking at it.
@@ -224,6 +224,20 @@ MoveTask::DoWork()
             }   // if
         }   // if
     }   // if
+
+    // hung iterator debug
+    {
+        struct timeval tv;
+
+        gettimeofday(&tv, NULL);
+        
+        // 14400 is 4 hours in seconds ... 60*60*4
+        if ((m_ItrWrap->m_LastLogReport + 14400) < tv.tv_sec && NULL!=m_ItrWrap->get())
+        {
+            m_ItrWrap->LogIterator();
+            m_ItrWrap->m_LastLogReport=tv.tv_sec;
+        }   // if
+    }
 
     // back to normal operation
     if(NULL == itr)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -307,7 +307,7 @@ MoveTask::DoWork()
         {
             // using compare_and_swap as a hardware locking "set to false"
             //  (a little heavy handed, but not executed often)
-            leveldb::compare_and_swap(&m_ItrWrap->m_PrefetchStarted, true, false);
+            leveldb::compare_and_swap(&m_ItrWrap->m_PrefetchStarted, (int)true, (int)false);
             return work_result(local_env(), ATOM_ERROR, ATOM_INVALID_ITERATOR);
         }   // else
 

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {erl_opts, [warnings_as_errors, debug_info]}.
 
 {deps, [
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "2.0"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.
 
 {port_env, [

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -120,7 +120,7 @@ init() ->
                           {delete, Key::binary()} |
                           clear].
 
--type iterator_action() :: first | last | next | prev | prefetch | binary().
+-type iterator_action() :: first | last | next | prev | prefetch | prefetch_stop | binary().
 
 -opaque db_ref() :: binary().
 

--- a/test/iterators.erl
+++ b/test/iterators.erl
@@ -37,7 +37,10 @@ iterator_test_() ->
         prev_test_case(Ref),
         seek_and_next_test_case(Ref),
         basic_prefetch_test_case(Ref),
-        seek_and_prefetch_test_case(Ref)
+        seek_and_prefetch_test_case(Ref),
+        aae_prefetch1(Ref),
+        aae_prefetch2(Ref),
+        aae_prefetch3(Ref)
        ]
        end}]
     }.
@@ -108,6 +111,36 @@ seek_and_prefetch_test_case(Ref) ->
             ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop)),
             ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop)),
             ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>))
+    end.
+
+aae_prefetch1(Ref) ->
+    fun() ->
+            {ok, I} = eleveldb:iterator(Ref, []),
+            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, <<"b">>)),
+            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch_stop)),
+
+            {ok, J} = eleveldb:iterator(Ref, []),
+            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, <<"z">>)),
+            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, prefetch_stop))
+    end.
+
+aae_prefetch2(Ref) ->
+    fun() ->
+            {ok, I} = eleveldb:iterator(Ref, []),
+            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, <<"b">>)),
+            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch)),
+            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch_stop)),
+
+            {ok, J} = eleveldb:iterator(Ref, []),
+            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, <<"z">>)),
+            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, prefetch)),
+            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, prefetch_stop))
+    end.
+
+aae_prefetch3(Ref) ->
+    fun() ->
+            {ok, I} = eleveldb:iterator(Ref, []),
+            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop))
     end.
 
 -endif.


### PR DESCRIPTION
Isolate leveldb iterator Valid() state.  This allows the iterator to be destroyed on background thread, releasing leveldb snapshot.  The foreground thread is then able to read the Valid() state at its leisure.
