### PR TITLE
integrate open source expiry features into eleveldb option processing

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="mv-expiry"
+LEVELDB_VSN="expiry_beta1"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="expiry_beta1"
+LEVELDB_VSN=""
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN=""
+LEVELDB_VSN="mv-expiry"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -415,12 +415,13 @@ LevelIteratorWrapper::LogIterator()
     struct tm created;
 
     localtime_r(&m_IteratorCreated, &created);
+#if 0 // available in different branch
     leveldb::Log(m_DbPtr->m_Db->GetLogger(),
                  "Iterator created %d/%d/%d %d:%d:%d, move operations %zd (%p)",
                  created.tm_mon, created.tm_mday, created.tm_year-100,
                  created.tm_hour, created.tm_min, created.tm_sec,
                  m_MoveCount, m_Iterator);
-
+#endif
 }   // LevelIteratorWrapper::LogIterator()
 
 

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -239,3 +239,31 @@
   {datatype, {enum, [true, false]}},
   hidden
 ]}.
+
+%% @doc Enable global expiry.  All leveldb databases / vnodes
+%% will use same expiry_minutes and whole_file_expiry settings.
+%% Same settings apply to all leveldb instances in multi_backend.
+{mapping, "leveldb.expiry_enabled", "eleveldb.expiry_enabled", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+
+%% @doc Minutes until object expires.  Gives number of minutes
+%% a stored key/value will stay within the database before automatic
+%% deletion.  Zero disables expiry by age (minutes) feature
+{mapping, "leveldb.expiry_minutes", "eleveldb.expiry_minutes", [
+  {default, 0},
+  {datatype, integer},
+  hidden
+]}.
+
+%% @doc Expire entire .sst table file.  Authorizes leveldb to
+%% eliminate entire files that contain expired data (delete files
+%% instead of removing expired key/values during compaction).
+{mapping, "leveldb.whole_file_expiry", "eleveldb.whole_file_expiry", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+

--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -165,3 +165,24 @@
   hidden
 ]}.
 
+%% @see leveldb.expiry_enabled
+{mapping, "multi_backend.$name.leveldbexpiry_enabled", "riak_kv.multi_backend", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+
+%% @see leveldb.expiry_minutes
+{mapping, "multi_backend.$name.leveldbexpiry_minutes", "riak_kv.multi_backend", [
+  {default, 0},
+  {datatype, integer},
+  hidden
+]}.
+
+%% @see leveldb.whole_file_expiry
+{mapping, "multi_backend.$name.leveldbwhole_file_expiry", "riak_kv.multi_backend", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -103,7 +103,11 @@ init() ->
                          {tiered_slow_level, pos_integer()} |
                          {tiered_fast_prefix, string()} |
                          {tiered_slow_prefix, string()} |
-                         {cache_object_warming, boolean()}].
+                         {cache_object_warming, boolean()} |
+                         {expiry_enabled, boolean()} |
+                         {expiry_minutes, pos_integer()} |
+                         {whole_file_expiry, boolean()}
+                        ].
 
 -type read_option() :: {verify_checksums, boolean()} |
                        {fill_cache, boolean()} |
@@ -307,7 +311,10 @@ option_types(open) ->
      {tiered_slow_level, integer},
      {tiered_fast_prefix, any},
      {tiered_slow_prefix, any},
-     {cache_object_warming, bool}];
+     {cache_object_warming, bool},
+     {expiry_enabled, bool},
+     {expiry_minutes, integer},
+     {whole_file_expiry, bool}];
 
 option_types(read) ->
     [{verify_checksums, bool},


### PR DESCRIPTION
Automatically add an ExpiryModuleOS object to leveldb::Options if any one of the 3 expiry options seen.  Only need one instance of the object and it will auto destruct after last pointer released.
