### PR TITLE
Bumped cuttlefish dependency to 2.0.7

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
 {erl_opts, [warnings_as_errors, debug_info]}.
 
 {deps, [
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.6"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.7"}}}
        ]}.
 
 {port_env, [


### PR DESCRIPTION
This is off the 2.2 branch (ostensibly for riak develop-2.2).  Similar changes will likely need to make on the numerous other branches of this repo.
