### PR TITLE
Disable cuttlefish dependency except for buildbot tests

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="mv-no-cuttlefish"
+LEVELDB_VSN=""
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN=""
+LEVELDB_VSN="mv-no-cuttlefish"
 
 SNAPPY_VSN="1.0.4"
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,9 +8,14 @@
 
 {erl_opts, [warnings_as_errors, debug_info]}.
 
-{deps, [
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
-       ]}.
+%%
+%% The following 3 lines are only activated during builbot
+%%  unit tests.  The buildbot script executes the following:
+%%    sed -i -e 's/% #!sed //' rebar.config test/eleveldb_schema_tests.erl
+%%
+% #!sed {deps, [
+% #!sed         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
+% #!sed        ]}.
 
 {port_env, [
          %% Make sure to set -fPIC when compiling leveldb

--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -1,8 +1,14 @@
 -module(eleveldb_schema_tests).
 
--include_lib("eunit/include/eunit.hrl").
--compile(export_all).
+%%
+%% The following 2 lines are only activated during builbot
+%%  unit tests.  The buildbot script executes the following:
+%%    sed -i -e 's/% #!sed //' rebar.config test/eleveldb_schema_tests.erl
+%%
+% #!sed -include_lib("eunit/include/eunit.hrl").
+% #!sed -compile(export_all).
 
+-compile(nowarn_unused_function).
 
 %% basic schema test will check to make sure that all defaults from
 %% the schema make it into the generated app.config


### PR DESCRIPTION
eleveldb does not care about cuttlefish dependencies.  However, there currently exist three active branches of eleveldb due solely to other Riak code that is specific about cuttlefish.

The branch comments out the rebar.config "deps" block.  And it comments out the two lines that enable cuttlefish unit tests within test/eleveldb_schema_tests.erl.  The comments use a tag that is removed via a sed command during buildbot unit tests.  Then the default cuttlefish on develop is used to validate the eleveldb .schema files.
