### PR TITLE
Use snappy with configurations not explicitly requesting lz4

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -2,7 +2,7 @@
 //
 // eleveldb: Erlang Wrapper for LevelDB (http://code.google.com/p/leveldb/)
 //
-// Copyright (c) 2011-2015 Basho Technologies, Inc. All Rights Reserved.
+// Copyright (c) 2011-2016 Basho Technologies, Inc. All Rights Reserved.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -365,14 +365,14 @@ ERL_NIF_TERM parse_open_option(ErlNifEnv* env, ERL_NIF_TERM item, leveldb::Optio
         else if (option[0] == eleveldb::ATOM_COMPRESSION)
         {
             if (option[1] == eleveldb::ATOM_ON || option[1] == eleveldb::ATOM_TRUE
-                || option[1] == eleveldb::ATOM_LZ4)
-            {
-                opts.compression = leveldb::kLZ4Compression;
-            }   // if
-
-            else if (option[1] == eleveldb::ATOM_SNAPPY )
+                || option[1] == eleveldb::ATOM_SNAPPY)
             {
                 opts.compression = leveldb::kSnappyCompression;
+            }   // if
+
+            else if (option[1] == eleveldb::ATOM_LZ4 )
+            {
+                opts.compression = leveldb::kLZ4Compression;
             }   // else if
 
             else

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -162,6 +162,10 @@
   {datatype, flag}
 ]}.
 
+%% @doc Selection of compression algorithms.  snappy is
+%% original compression supplied for leveldb.  lz4 is new
+%% algorithm that compresses to similar volume but averages twice
+%% as fast on writes and four times as fast on reads.
 {mapping, "leveldb.compression.algorithm", "eleveldb.compression", [
   {new_conf_value, lz4},
   {datatype, {enum, [snappy, lz4]}}

--- a/priv/eleveldb.schema
+++ b/priv/eleveldb.schema
@@ -159,14 +159,12 @@
 %% next time a file requires compaction.
 {mapping, "leveldb.compression", "eleveldb.compression", [
   {default, on},
-  {datatype, flag},
-  hidden
+  {datatype, flag}
 ]}.
 
 {mapping, "leveldb.compression.algorithm", "eleveldb.compression", [
-  {default, lz4},
-  {datatype, {enum, [snappy, lz4]}},
-  hidden
+  {new_conf_value, lz4},
+  {datatype, {enum, [snappy, lz4]}}
 ]}.
 
 {translation,
@@ -176,7 +174,7 @@
     case Setting of
       false -> false;
       true ->
-        cuttlefish:conf_get("leveldb.compression.algorithm", Conf, lz4)
+        cuttlefish:conf_get("leveldb.compression.algorithm", Conf, snappy)
     end
  end}.
 

--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -117,16 +117,14 @@
   "multi_backend.$name.leveldb.compression",
   "riak_kv.multi_backend", [
   {default, on},
-  {datatype, flag},
-  hidden
+  {datatype, flag}
 ]}.
 
 {mapping,
   "multi_backend.$name.leveldb.compression.algorithm",
   "riak_kv.multi_backend", [
-  {default, lz4},
-  {datatype, {enum, [snappy, lz4]}},
-  hidden
+  {new_conf_value, lz4},
+  {datatype, {enum, [snappy, lz4]}}
 ]}.
 
 %% @see leveldb.delete_threshold

--- a/src/eleveldb.app.src
+++ b/src/eleveldb.app.src
@@ -16,6 +16,11 @@
          {total_leveldb_mem_percent, 15},
 
          %% Use bloom filter support by default
-         {use_bloomfilter, true}
+         {use_bloomfilter, true},
+
+         %% Users with "older" configs should get
+         %%  "older" compression by default
+         {compression, snappy}
+
         ]}
  ]}.

--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -134,7 +134,7 @@ compression_schema_test() ->
     Config2 = cuttlefish_unit:generate_templated_config(
         ["../priv/eleveldb.schema"], Case2, context(), predefined_schema()),
 
-    cuttlefish_unit:assert_config(Config2, "eleveldb.compression", lz4),
+    cuttlefish_unit:assert_config(Config2, "eleveldb.compression", snappy),
 
 
     %% Case3:  compression enabled, explicitly set lz4 as algorithm
@@ -157,6 +157,23 @@ compression_schema_test() ->
         ["../priv/eleveldb.schema"], Case4, context(), predefined_schema()),
 
     cuttlefish_unit:assert_config(Config4, "eleveldb.compression", snappy),
+
+    %% Case5:  compression enabled by default, explicitly set lz4 as algorithm
+    Case5 = [
+            {["leveldb", "compression", "algorithm"], lz4}
+           ],
+    Config5 = cuttlefish_unit:generate_templated_config(
+        ["../priv/eleveldb.schema"], Case5, context(), predefined_schema()),
+
+    cuttlefish_unit:assert_config(Config5, "eleveldb.compression", lz4),
+
+    %% Case6:  compression enabled by default, snappy by default
+    Case6 = [
+           ],
+    Config6 = cuttlefish_unit:generate_templated_config(
+        ["../priv/eleveldb.schema"], Case6, context(), predefined_schema()),
+
+    cuttlefish_unit:assert_config(Config6, "eleveldb.compression", snappy),
 
 
     ok.

--- a/test/eleveldb_schema_tests.erl
+++ b/test/eleveldb_schema_tests.erl
@@ -34,7 +34,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "eleveldb.eleveldb_threads", 71),
     cuttlefish_unit:assert_config(Config, "eleveldb.fadvise_willneed", false),
     cuttlefish_unit:assert_config(Config, "eleveldb.delete_threshold", 1000),
-    cuttlefish_unit:assert_config(Config, "eleveldb.compression", lz4),
+    cuttlefish_unit:assert_config(Config, "eleveldb.compression", snappy),
     cuttlefish_unit:assert_config(Config, "eleveldb.tiered_slow_level", 0),
     cuttlefish_unit:assert_not_configured(Config, "eleveldb.tiered_fast_prefix"),
     cuttlefish_unit:assert_not_configured(Config, "eleveldb.tiered_slow_prefix"),


### PR DESCRIPTION
Goal for compression defaults:
1. leveldb open source users:  lz4 default
2. eleveldb open source users:  snappy default
3. riak.conf / app.config users of older generation: snappy default
4. riak.conf from Riak 2.2: lz4 default
#1 (RIAK-1433) manually verified in leveldb tests.
#2, #3, #4 (RIAK-1556) (RIAK-1556) verified in eleveldb_schema_tests.erl
#4 (RIAK-1556) (RIAK-1556) also verified by building riak from scratch using mv-cuttle-lz4 eleveldb & cuttlefish develop, then "make stage" ... riak.conf has lz4 compression:

mmaszewski@puma:~/riak$ grep compress rel/riak/etc/riak.conf

leveldb.compression = on
leveldb.compression.algorithm = lz4
multi_backend.name.leveldb.compression = on
multi_backend.name.leveldb.compression.algorithm = lz4
