### PR TITLE
Make multi_backend compression settings commented

### DIFF
--- a/priv/eleveldb_multi.schema
+++ b/priv/eleveldb_multi.schema
@@ -117,13 +117,14 @@
   "multi_backend.$name.leveldb.compression",
   "riak_kv.multi_backend", [
   {default, on},
+  {commented, on},
   {datatype, flag}
 ]}.
 
 {mapping,
   "multi_backend.$name.leveldb.compression.algorithm",
   "riak_kv.multi_backend", [
-  {new_conf_value, lz4},
+  {commented, lz4},
   {datatype, {enum, [snappy, lz4]}}
 ]}.
 


### PR DESCRIPTION
These should only be appearing in riak.conf for documentation, as they
won't be needed unless a user is setting up multi_backend. (Even then
they will probably want to change the backend name to something other
than "name".)
