### PR TITLE
Add Riak TS "IS NULL" and "IS NOT NULL" handling

### DIFF
--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -319,19 +319,6 @@ std::vector<unsigned char> ErlUtil::getBinary(ErlNifEnv* env, ERL_NIF_TERM term)
 
     ErlNifBinary bin;
 
-    // SQL NULL represented as [] w/i Riak TS
-    if(enif_is_list(env, term)) {
-        unsigned length;
-        if(enif_get_list_length(env, term, &length)) {
-            if(length == 0) {
-                ret.resize(0);
-                return ret;
-            }
-        }
-        ThrowRuntimeError("Invalid list as binary, only empty list may be" <<
-                " treated as a binary");
-    }
-
     if(enif_inspect_binary(env, term, &bin) == 0)
         ThrowRuntimeError("Failed to inspect '" << formatTerm(env, term)
                           << "' as a binary");
@@ -341,6 +328,37 @@ std::vector<unsigned char> ErlUtil::getBinary(ErlNifEnv* env, ERL_NIF_TERM term)
 
     return ret;
 }
+
+std::vector<unsigned char> ErlUtil::getBinaryOrEmptyList()
+{
+    checkTerm();
+    return getBinaryOrEmptyList(term_);
+}
+
+std::vector<unsigned char> ErlUtil::getBinaryOrEmptyList(ERL_NIF_TERM term)
+{
+    checkEnv();
+    return getBinaryOrEmptyList(env_, term);
+}
+
+std::vector<unsigned char> ErlUtil::getBinaryOrEmptyList(ErlNifEnv* env, ERL_NIF_TERM term)
+{
+    // SQL NULL represented as [] w/i Riak TS
+    if(enif_is_list(env, term)) {
+        unsigned length;
+        if(enif_get_list_length(env, term, &length)) {
+            if(length == 0) {
+                std::vector<unsigned char> ret(0);
+                return ret;
+            }
+        }
+        ThrowRuntimeError("Invalid list as binary, only empty list may be" <<
+                " treated as a binary");
+    }
+
+    return getBinary(env, term);
+}
+
 
 std::string ErlUtil::getString()
 {

--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -319,6 +319,17 @@ std::vector<unsigned char> ErlUtil::getBinary(ErlNifEnv* env, ERL_NIF_TERM term)
 
     ErlNifBinary bin;
 
+    // SQL NULL represented as [] w/i Riak TS
+    if(enif_is_list(env, term)) {
+        unsigned length;
+        if(enif_get_list_length(env, term, &length)) {
+            if(length == 0) {
+                ret.resize(0);
+                return ret;
+            }
+        }
+    }
+
     if(enif_inspect_binary(env, term, &bin) == 0)
         ThrowRuntimeError("Failed to inspect '" << formatTerm(env, term)
                           << "' as a binary");
@@ -582,7 +593,7 @@ std::vector<std::pair<std::string, ERL_NIF_TERM> > ErlUtil::getListTuples(ERL_NI
         const ERL_NIF_TERM* array=0;
         if(enif_get_tuple(env_, curr, &arity, &array)==0)
             ThrowRuntimeError("Unable to get tuple");
-  
+
         if(arity != 2)
             ThrowRuntimeError("Malformed tuple");
 

--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -328,6 +328,8 @@ std::vector<unsigned char> ErlUtil::getBinary(ErlNifEnv* env, ERL_NIF_TERM term)
                 return ret;
             }
         }
+        ThrowRuntimeError("Invalid list as binary, only empty list may be" <<
+                " treated as a binary");
     }
 
     if(enif_inspect_binary(env, term, &bin) == 0)

--- a/c_src/ErlUtil.h
+++ b/c_src/ErlUtil.h
@@ -85,6 +85,10 @@ namespace eleveldb {
         std::vector<unsigned char> getBinary(ERL_NIF_TERM term);
         static std::vector<unsigned char> getBinary(ErlNifEnv* env, ERL_NIF_TERM term);
 
+        std::vector<unsigned char> getBinaryOrEmptyList();
+        std::vector<unsigned char> getBinaryOrEmptyList(ERL_NIF_TERM term);
+        static std::vector<unsigned char> getBinaryOrEmptyList(ErlNifEnv* env, ERL_NIF_TERM term);
+
         std::vector<ERL_NIF_TERM> getListCells();
         std::vector<ERL_NIF_TERM> getListCells(ERL_NIF_TERM term);
         static std::vector<ERL_NIF_TERM> getListCells(ErlNifEnv* env, 

--- a/c_src/filter.h
+++ b/c_src/filter.h
@@ -329,6 +329,8 @@ public:
 
     virtual bool evaluate() const {
         // [] to represent NULL w/i Riak TS, which does NOT conflict w/ <<"">>.
+        // NOTE: comparison to NULL is always rewritten with NULL on the
+        // right-hand-side of the equality comparison
         if(right_->size() == 0) {
             return !left_->has_value();
         }
@@ -388,6 +390,8 @@ public:
 
     virtual bool evaluate() const {
         // [] to represent NULL w/i Riak TS, which does NOT conflict w/ <<"">>.
+        // NOTE: comparison to NULL is always rewritten with NULL on the
+        // right-hand-side of the equality comparison
         if(right_->size() == 0) {
             return left_->has_value();
         }

--- a/c_src/filter.h
+++ b/c_src/filter.h
@@ -328,19 +328,21 @@ public:
     virtual ~EqOperator() {};
 
     virtual bool evaluate() const {
+        // [] to represent NULL w/i Riak TS, which does NOT conflict w/ <<"">>.
+        if(right_->size() == 0) {
+            return !left_->has_value();
+        }
 
         if(!BinaryExpression<bool,unsigned char*>::has_value())
-           return false;
+            return false;
 
         // If the sizes are equal, compare memory blocks
-
         if(left_->size() == right_->size()) {
             bool eq = (memcmp(left_->evaluate(), right_->evaluate(), left_->size()) == 0);
             return eq;
         }
 
         // Else not equal
-
         return false;
     }
 };
@@ -385,6 +387,10 @@ public:
     virtual ~NeqOperator() {};
 
     virtual bool evaluate() const {
+        // [] to represent NULL w/i Riak TS, which does NOT conflict w/ <<"">>.
+        if(right_->size() == 0) {
+            return left_->has_value();
+        }
 
         if(!BinaryExpression<bool,unsigned char*>::has_value())
             return false;

--- a/c_src/filter_parser.cc
+++ b/c_src/filter_parser.cc
@@ -124,7 +124,7 @@ parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
 
 template<> ExpressionNode<unsigned char*>* 
 parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
-    std::vector<unsigned char> val = eleveldb::ErlUtil::getBinary(env, operand);
+    std::vector<unsigned char> val = eleveldb::ErlUtil::getBinaryOrEmptyList(env, operand);
     return new ConstantValue<unsigned char*>(val);
 }
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -1017,9 +1017,11 @@ work_result RangeScanTask::DoWork()
                 if(range_filter_) {
 
                     //------------------------------------------------------------
-                    // Also check if the key can be parsed.  If TS-encoded
-                    // data and non-TS encoded data are interleaved, this
-                    // causes us to ignore the non-TS-encoded data
+                    // Also check if the key can be parsed.
+                    //
+                    // Since TS-encoded and non-TS-encoded data can NOT be
+                    // interleaved, we are throwing if the riak object contents
+                    // can not be parsed.
                     //------------------------------------------------------------
                     
                     if(extractor_->riakObjectContentsCanBeParsed(value.data(), value.size())) {
@@ -1034,7 +1036,6 @@ work_result RangeScanTask::DoWork()
 
                     } else {
                         ThrowRuntimeError("range_filter set, but couldn't parse riak object");
-                        filter_passed = false;
                     }
                 }
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -1033,6 +1033,7 @@ work_result RangeScanTask::DoWork()
                         filter_passed = range_filter_->evaluate();
 
                     } else {
+                        ThrowRuntimeError("range_filter set, but couldn't parse riak object");
                         filter_passed = false;
                     }
                 }

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -503,7 +503,12 @@ putKeyNormalOps(Ref) ->
                       10 -> [];
                       12 -> [];
                       _ -> I * 1000
-              end} %%<< sint64
+              end}, %%<< sint64 stored as a small num
+              {<<"f7">>, case I of
+                      10 -> [];
+                      12 -> [];
+                      _ -> 1467563367600 + I * 1000
+              end} %%<< sint64 stored as a big num
              ] || I <- lists:seq(1, FieldCount * 2) ], %%<< twice to store a NULL value for each field type
     lists:foreach(fun (Row) ->
                 I = element(2, hd(Row)),
@@ -878,6 +883,9 @@ isNullBoolean_test() ->
 isNullInteger_test() ->
     isNullFieldOfTypeTestFactory(true, <<"f6">>).
 
+isNullLargeInteger_test() ->
+    isNullFieldOfTypeTestFactory(true, <<"f7">>).
+
 isNotNullBinary_test() ->
     isNullFieldOfTypeTestFactory(false, <<"f2">>).
 
@@ -889,6 +897,9 @@ isNotNullBoolean_test() ->
 
 isNotNullInteger_test() ->
     isNullFieldOfTypeTestFactory(false, <<"f6">>).
+
+isNotNullLargeInteger_test() ->
+    isNullFieldOfTypeTestFactory(false, <<"f7">>).
 
 %%=======================================================================
 %% Test various exceptional conditions

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -445,7 +445,7 @@ match(V1,V2,CompFun) ->
     end.
 
 fieldsMatching(Vals, Field, CompVal, CompFun) ->
-%    io:format("Got Vals = ~p~n", [lists:flatten(Vals)]),
+    %% io:format("Got Vals = ~p~n", [lists:flatten(Vals)]),
     lists:foldl(fun(Val, {N, Nmatch}) -> 
 			{N + 1, Nmatch + match(Val, Field, CompVal, CompFun)} end, {0,0}, Vals).
 
@@ -477,18 +477,72 @@ packObj_test() ->
 %%-----------------------------------------------------------------------
 
 putKeyNormalOps(Ref) ->
-    addKey(Ref, 1, [{<<"f1">>, 1}, {<<"f2">>, <<"test1">>}, {<<"f3">>, 1.0}, {<<"f4">>, false}, {<<"f5">>, [1,2,3]}, {<<"f6">>, 1000}]),
-    addKey(Ref, 2, [{<<"f1">>, 2}, {<<"f2">>, <<"test2">>}, {<<"f3">>, 2.0}, {<<"f4">>, true},  {<<"f5">>, [2,3,4]}, {<<"f6">>, 2000}]),
-    addKey(Ref, 3, [{<<"f1">>, 3}, {<<"f2">>, <<"test3">>}, {<<"f3">>, 3.0}, {<<"f4">>, false}, {<<"f5">>, [3,4,5]}, {<<"f6">>, 3000}]),
-    addKey(Ref, 4, [{<<"f1">>, 4}, {<<"f2">>, <<"test4">>}, {<<"f3">>, 4.0}, {<<"f4">>, true},  {<<"f5">>, [4,5,6]}, {<<"f6">>, 4000}]).
+    FieldCount = 6,
+    Rows = [ [{<<"f1">>, I },
+              {<<"f2">>, case I of
+                      2 -> [];
+                      12 -> [];
+                      _ -> list_to_binary("test" ++ integer_to_list(I))
+              end}, %%<< varchar
+              {<<"f3">>, case I of
+                      4 -> [];
+                      12 -> [];
+                      _ -> I * 1.0
+              end}, %%<< double
+              {<<"f4">>, case I of
+                      6 -> [];
+                      12 -> [];
+                      _ -> I rem 2 =:= 0
+              end}, %%<< boolean
+              {<<"f5">>, case I of
+                      8 -> [];
+                      12 -> [];
+                      _ -> lists:seq(I, I + 2)
+              end}, %%<< list (not a TS type)
+              {<<"f6">>, case I of
+                      10 -> [];
+                      12 -> [];
+                      _ -> I * 1000
+              end} %%<< sint64
+             ] || I <- lists:seq(1, FieldCount * 2) ], %%<< twice to store a NULL value for each field type
+    lists:foreach(fun (Row) ->
+                I = element(2, hd(Row)),
+                addKey(Ref, I, Row)
+        end, Rows).
 
+defaultEvalFn({Val,NullMatch=[]}) ->
+    ?assertEqual(Val, NullMatch);
+defaultEvalFn({Null=[], NullMatch}) ->
+    ?assertEqual(Null, NullMatch);
 defaultEvalFn({N,Nmatch}) ->
+    ?assertEqual(Nmatch, N),
     (N > 0) and (N == Nmatch).
 
 filterVal({FilterVal}) ->
     FilterVal;
 filterVal({FilterVal, _CompVal}) ->
     FilterVal.
+
+isNullOpsFactory(IsNull, Field, PutFn, EvalFn) ->
+    %% for NULL equality check, cast to binary is needed, the alternative of
+    %% creating an is_null and is_not_null expression w/i eleveldb is considered
+    %% but unless performance suffers, a binary comparison to reuse equality
+    %% and nonEquality comparitors is preferable.
+    Type = varchar,
+    Val = [],
+    Op = case IsNull of
+        true -> '=';
+        _ -> '!='
+    end,
+    Filter = {Op, {field, Field, Type}, {const, Val}},
+    Keys = streamFoldTest(Filter, PutFn),
+    EvalFn(fieldsMatching(Keys, Field, Val, fun(V1,V2) -> V1 == V2 end)).
+
+isNullOps({Field, _Val, _Type, PutFn, EvalFn}) ->
+    isNullOpsFactory(true, Field, PutFn, EvalFn).
+
+isNotNullOps({Field, _Val, _Type, PutFn, EvalFn}) ->
+    isNullOpsFactory(false, Field, PutFn, EvalFn).
 
 eqOps({Field, Val, Type, PutFn, EvalFn}) ->
     Filter = {'=', {field, Field, Type}, {const, filterVal(Val)}},
@@ -620,10 +674,10 @@ boolOps_test() ->
 anyOps_test() ->
     io:format("anyOps_test~n"),
     F = <<"f5">>,
-    Val = sut:em([1,2,3]),
+    Val = em([1,2,3]),
     CompVal = [1,2,3],
-    PutFn  = fun sut:putKeyNormalOps/1,
-    EvalFn = fun sut:defaultEvalFn/1,
+    PutFn  = fun putKeyNormalOps/1,
+    EvalFn = fun defaultEvalFn/1,
     Res = eqOpsOnly({F, {Val, CompVal}, any, PutFn, EvalFn}) and (anyCompOps({F, {Val, CompVal}, any, PutFn, EvalFn}) == false),
     ?assert(Res),
     Res.
@@ -645,16 +699,19 @@ normalOpsTests() ->
 
 andOps_test() ->
     io:format("andOps_test~n"),
-    Cond1 = {'>', {field, <<"f1">>, sint64}, {const, 2}},
-    Cond2 = {'=', {field, <<"f3">>, double}, {const, 4.0}},
+    Cond1 = {'>', {field, <<"f1">>, sint64}, {const, 3}},
+    Cond2 = {'=', {field, <<"f3">>, double}, {const, 5.0}},
     Filter = {'and_', Cond1, Cond2},
-    PutFn  = fun sut:putKeyNormalOps/1,
+    PutFn  = fun putKeyNormalOps/1,
     Keys = streamFoldTest(Filter, PutFn),
-    {N1, NMatch1} = fieldsMatching(Keys, <<"f1">>, 2,   fun(V1,V2) -> V1 > V2 end),
-    {N3, NMatch3} = fieldsMatching(Keys, <<"f3">>, 4.0, fun(V1,V2) -> V1 == V2 end),
-    Res = (N1 == 1) and (NMatch1 == 1) and (N3 == 1) and (NMatch3 == 1),
-    ?assert(Res),
-    Res.
+    {N1, NMatch1} = fieldsMatching(Keys, <<"f1">>, 3,   fun(V1,V2) -> V1 > V2 end),
+    {N3, NMatch3} = fieldsMatching(Keys, <<"f3">>, 5.0, fun(V1,V2) -> V1 == V2 end),
+    ?assertEqual(1, N1),
+    ?assertEqual(1, NMatch1),
+    ?assertEqual(1, N3),
+    ?assertEqual(1, NMatch3),
+    pass.
+
 
 %%------------------------------------------------------------
 %% Test OR filtering
@@ -662,16 +719,18 @@ andOps_test() ->
 
 orOps_test() ->
     io:format("orOps_test~n"),
-    Cond1 = {'>', {field, <<"f1">>, sint64}, {const, 2}},
-    Cond2 = {'=', {field, <<"f3">>, double}, {const, 4.0}},
+    Cond1 = {'>', {field, <<"f1">>, sint64}, {const, 3}},
+    Cond2 = {'=', {field, <<"f3">>, double}, {const, 5.0}},
     Filter = {'or_', Cond1, Cond2},
-    PutFn  = fun sut:putKeyNormalOps/1,
+    PutFn  = fun putKeyNormalOps/1,
     Keys = streamFoldTest(Filter, PutFn),
-    {N1, NMatch1} = fieldsMatching(Keys, <<"f1">>, 2,   fun(V1,V2) -> V1 > V2 end),
-    {N3, NMatch3} = fieldsMatching(Keys, <<"f3">>, 4.0, fun(V1,V2) -> V1 == V2 end),
-    Res = (N1 == 2) and (NMatch1 == 2) and (N3 == 2) and (NMatch3 == 1),
-    ?assert(Res),
-    Res.
+    {N1, NMatch1} = fieldsMatching(Keys, <<"f1">>, 3,   fun(V1,V2) -> V1 > V2 end),
+    {N3, NMatch3} = fieldsMatching(Keys, <<"f3">>, 5.0, fun(V1,V2) -> V1 == V2 end),
+    ?assertEqual(7, N1),
+    ?assertEqual(7, NMatch1),
+    ?assertEqual(7, N3),
+    ?assertEqual(1, NMatch3),
+    pass.
 
 %%------------------------------------------------------------
 %% Test all AND + OR ops
@@ -773,12 +832,12 @@ badBool_test() ->
 badAny_test() ->
     io:format("badAny_test~n"),
     F = <<"f5">>,
-    Val = sut:em([1,2,3]),
+    Val = em([1,2,3]),
     CompVal = [1,2,3],
-    PutFn  = fun sut:putKeyNormalOps/1,
-    Res = neqOps({F, {Val, CompVal}, any, PutFn, fun({N,_}) -> N == 3 end}),
-    ?assert(Res),
-    Res.
+    PutFn  = fun putKeyNormalOps/1,
+    ExpectedRowCount = 9,
+    EvalFn = fun({N,_}) -> ?assertEqual(ExpectedRowCount, N) end,
+    neqOps({F, {Val, CompVal}, any, PutFn, EvalFn}).
 
 %%------------------------------------------------------------
 %% All abnormal ops tests
@@ -786,6 +845,50 @@ badAny_test() ->
 
 abnormalOpsTests() ->
     badInt_test() and badBinary_test() and badFloat_test() and badBool_test() and badTimestamp_test() and badAny_test().
+
+%%=======================================================================
+%% Test filter on IS NULL and IS NOT NULL
+%%=======================================================================
+isNullFieldOfTypeTestFactory(IsNull, Field) ->
+    %% if curious why varchar, see comment on isNullOpsFactory
+    Type = varchar,
+    Val = [],
+    CompVal = [],
+    PutFn = fun putKeyNormalOps/1,
+    ExpectedRowCount = case IsNull of
+        true -> 2;
+        _ -> 10
+    end,
+    EvalFn = fun({N,_}) -> ?assertEqual(ExpectedRowCount, N) end,
+    IsNullOpsFn = case IsNull of
+        true -> fun isNullOps/1;
+        _ -> fun isNotNullOps/1
+    end,
+    IsNullOpsFn({Field, {Val, CompVal}, Type, PutFn, EvalFn}).
+
+isNullBinary_test() ->
+    isNullFieldOfTypeTestFactory(true, <<"f2">>).
+
+isNullDouble_test() ->
+    isNullFieldOfTypeTestFactory(true, <<"f3">>).
+
+isNullBoolean_test() ->
+    isNullFieldOfTypeTestFactory(true, <<"f4">>).
+
+isNullInteger_test() ->
+    isNullFieldOfTypeTestFactory(true, <<"f6">>).
+
+isNotNullBinary_test() ->
+    isNullFieldOfTypeTestFactory(false, <<"f2">>).
+
+isNotNullDouble_test() ->
+    isNullFieldOfTypeTestFactory(false, <<"f3">>).
+
+isNotNullBoolean_test() ->
+    isNullFieldOfTypeTestFactory(false, <<"f4">>).
+
+isNotNullInteger_test() ->
+    isNullFieldOfTypeTestFactory(false, <<"f6">>).
 
 %%=======================================================================
 %% Test various exceptional conditions


### PR DESCRIPTION
NOTE: this is the part 1 of a 3 PR set to implement Riak TS "IS NULL" and "IS NOT NULL".
- added eleveldb handling of Riak TS SQL "WHERE <field> IS NULL", using existing equality and non-equality comparitors.
  - !IMPORTANT! IMHO this is the most controversial aspect of the change.
  - An alternative would be to add an IsNullOperator (and likely also an IsNotNullOperator) and expression tree construction for these "IS NULL" and "IS NOT NULL" expression tree leaves.
- added WARN on build_deps for leveldb dep out-of-sync.
- reworked unit tests to include NULL rows, using ?assert macros to make the tests easier to fix on such changes.
