### PR TITLE
Switch to reference counted pointers instead of naked pointers.

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN=""
+LEVELDB_VSN="hack22"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -727,7 +727,7 @@ async_write(
     fold(env, argv[3], parse_write_option, *opts);
 
     eleveldb::WorkTask* work_item = new eleveldb::WriteTask(env, caller_ref,
-                                                            db_ptr.get(), batch, opts);
+                                                            db_ptr, batch, opts);
 
     if(false == priv.thread_pool.Submit(work_item))
     {
@@ -770,7 +770,7 @@ async_get(
     fold(env, opts_ref, parse_read_option, opts);
 
     eleveldb::WorkTask *work_item = new eleveldb::GetTask(env, caller_ref,
-                                                          db_ptr.get(), key_ref, opts);
+                                                          db_ptr, key_ref, opts);
 
     eleveldb_priv_data& priv = *static_cast<eleveldb_priv_data *>(enif_priv_data(env));
 
@@ -817,7 +817,7 @@ async_iterator(
     fold(env, options_ref, parse_read_option, opts);
 
     eleveldb::WorkTask *work_item = new eleveldb::IterTask(env, caller_ref,
-                                                           db_ptr.get(), keys_only, opts);
+                                                           db_ptr, keys_only, opts);
 
     // Now-boilerplate setup (we'll consolidate this pattern soon, I hope):
     eleveldb_priv_data& priv = *static_cast<eleveldb_priv_data *>(enif_priv_data(env));
@@ -983,7 +983,7 @@ async_iterator_move(
         eleveldb::MoveTask * move_item;
 
         move_item = new eleveldb::MoveTask(env, caller_ref,
-                                           itr_ptr->m_Iter.get(), action);
+                                           itr_ptr->m_Iter, action);
 
         // prevent deletes during worker loop
         move_item->RefInc();
@@ -1046,7 +1046,7 @@ async_close(
         && db_ptr->ClaimCloseFromCThread())
     {
         eleveldb::WorkTask *work_item = new eleveldb::CloseTask(env, caller_ref,
-                                                                db_ptr.get());
+                                                                db_ptr);
 
         // Now-boilerplate setup (we'll consolidate this pattern soon, I hope):
         eleveldb_priv_data& priv = *static_cast<eleveldb_priv_data *>(enif_priv_data(env));
@@ -1091,7 +1091,7 @@ async_iterator_close(
     if (itr_ptr->ClaimCloseFromCThread())
     {
         eleveldb::WorkTask *work_item = new eleveldb::ItrCloseTask(env, caller_ref,
-                                                                   itr_ptr.get());
+                                                                   itr_ptr);
 
         // Now-boilerplate setup (we'll consolidate this pattern soon, I hope):
         eleveldb_priv_data& priv = *static_cast<eleveldb_priv_data *>(enif_priv_data(env));

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -453,7 +453,7 @@ ItrObject::CreateItrObjectType(
 
 void *
 ItrObject::CreateItrObject(
-    DbObject * DbPtr,
+    DbObjectPtr_t & DbPtr,
     bool KeysOnly,
     leveldb::ReadOptions & Options)
 {
@@ -530,13 +530,13 @@ ItrObject::ItrObjectResourceCleanup(
 
 
 ItrObject::ItrObject(
-    DbObject * DbPtr,
+    DbObjectPtr_t & DbPtr,
     bool KeysOnly,
     leveldb::ReadOptions & Options)
     : keys_only(KeysOnly), m_ReadOptions(Options), reuse_move(NULL),
       m_DbPtr(DbPtr), itr_ref_env(NULL)
 {
-    if (NULL!=DbPtr)
+    if (NULL!=DbPtr.get())
         DbPtr->AddReference(this);
 
 }   // ItrObject::ItrObject

--- a/c_src/refobjects.cc
+++ b/c_src/refobjects.cc
@@ -341,7 +341,6 @@ DbObject::Shutdown()
 //            if (leveldb::compare_and_swap(itr_ptr->m_ErlangThisPtr, itr_ptr, (ItrObject *)NULL))
             if (itr_ptr->ClaimCloseFromCThread())
             {
-                itr_ptr->m_Wrap.LogIterator();
                 itr_ptr->ItrObject::InitiateCloseRequest();
             }   // if
         }   // if
@@ -394,46 +393,17 @@ LevelIteratorWrapper::LevelIteratorWrapper(
       m_Snapshot(NULL), m_Iterator(NULL),
       m_HandoffAtomic(0), m_PrefetchStarted(false),
       m_IteratorStale(0), m_StillUse(true),
-//      m_IteratorCreated(0), m_LastLogReport(0), m_MoveCount(0),
       m_IsValid(false)
 {
-#if 0
-    struct timeval tv;
-
-    gettimeofday(&tv, NULL);
-    m_IteratorCreated=tv.tv_sec;
-    m_LastLogReport=tv.tv_sec;
-#endif
 
     RebuildIterator();
 
 }   // LevelIteratorWrapper::LevelIteratorWrapper
 
-/**
- * put info about this iterator into leveldb LOG
- */
-
-void
-LevelIteratorWrapper::LogIterator()
-{
-#if 0 // available in different branch
-    struct tm created;
-
-    localtime_r(&m_IteratorCreated, &created);
-
-    leveldb::Log(m_DbPtr->m_Db->GetLogger(),
-                 "Iterator created %d/%d/%d %d:%d:%d, move operations %zd (%p)",
-                 created.tm_mon, created.tm_mday, created.tm_year-100,
-                 created.tm_hour, created.tm_min, created.tm_sec,
-                 m_MoveCount, m_Iterator);
-#endif
-}   // LevelIteratorWrapper::LogIterator()
-
 
 /**
  * Iterator management object (Erlang memory)
  */
-
 ErlNifResourceType * ItrObject::m_Itr_RESOURCE(NULL);
 
 
@@ -574,9 +544,6 @@ ItrObject::Shutdown()
     //  (reuse_move holds a counter to this object, which will
     //   release when move object destructs)
     ReleaseReuseMove();
-
-    // ItrObject and m_Wrap each hold pointers to other, release ours
-//    m_Wrap.assign(NULL);
 
     return;
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -123,7 +123,7 @@ public:
         : t(NULL)
     {};
 
-    ReferencePtr(TargetT *_t)
+    explicit ReferencePtr(TargetT *_t)
         : t(_t)
     {
         if (NULL!=t)
@@ -327,6 +327,8 @@ public:
     ItrObject(DbObjectPtr_t &, bool, leveldb::ReadOptions &);
 
     virtual ~ItrObject(); // needs to perform free_itr
+
+    virtual uint32_t RefDec();
 
     virtual void Shutdown();
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -207,6 +207,8 @@ private:
     DbObject& operator=(const DbObject&);   // nocopyassign
 };  // class DbObject
 
+typedef ReferencePtr<class DbObject> DbObjectPtr_t;
+
 
 /**
  * A self deleting wrapper to contain leveldb iterator.
@@ -303,6 +305,7 @@ private:
 
 };  // LevelIteratorWrapper
 
+typedef ReferencePtr<LevelIteratorWrapper> LevelIteratorWrapperPtr_t;
 
 
 /**
@@ -328,7 +331,7 @@ protected:
     static ErlNifResourceType* m_Itr_RESOURCE;
 
 public:
-    ItrObject(DbObject *, bool, leveldb::ReadOptions &);
+    ItrObject(DbObjectPtr_t &, bool, leveldb::ReadOptions &);
 
     virtual ~ItrObject(); // needs to perform free_itr
 
@@ -336,7 +339,7 @@ public:
 
     static void CreateItrObjectType(ErlNifEnv * Env);
 
-    static void * CreateItrObject(DbObject * Db, bool KeysOnly, leveldb::ReadOptions & Options);
+    static void * CreateItrObject(DbObjectPtr_t & Db, bool KeysOnly, leveldb::ReadOptions & Options);
 
     static ItrObject * RetrieveItrObject(ErlNifEnv * Env, const ERL_NIF_TERM & DbTerm,
                                          bool ItrClosing=false);
@@ -351,6 +354,8 @@ private:
     ItrObject & operator=(const ItrObject &); // no assignment
 
 };  // class ItrObject
+
+typedef ReferencePtr<class ItrObject> ItrObjectPtr_t;
 
 } // namespace eleveldb
 

--- a/c_src/refobjects.h
+++ b/c_src/refobjects.h
@@ -239,13 +239,6 @@ public:
     time_t m_IteratorStale;                   //!< time iterator should refresh
     bool m_StillUse;                          //!< true if no error or key end seen
 
-#if 0
-    // debug data for hung iteratos
-    time_t m_IteratorCreated;                 //!< time constructor called
-    time_t m_LastLogReport;                   //!< LOG message was last written
-    size_t m_MoveCount;                       //!< number of calls to MoveItem
-#endif
-
     // read by Erlang thread, maintained by eleveldb MoveItem::DoWork
     volatile bool m_IsValid;                  //!< iterator state after last operation
 
@@ -299,9 +292,6 @@ public:
         m_Options.snapshot = m_Snapshot;
         m_Iterator = m_DbPtr->m_Db->NewIterator(m_Options);
     }   // RebuildIterator
-
-    // hung iterator debug
-    void LogIterator();
 
 private:
     LevelIteratorWrapper(const LevelIteratorWrapper &);            // no copy

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -79,7 +79,7 @@ WorkTask::WorkTask(ErlNifEnv *caller_env, ERL_NIF_TERM& caller_ref)
 }   // WorkTask::WorkTask
 
 
-WorkTask::WorkTask(ErlNifEnv *caller_env, ERL_NIF_TERM& caller_ref, DbObject * DbPtr)
+WorkTask::WorkTask(ErlNifEnv *caller_env, ERL_NIF_TERM& caller_ref, DbObjectPtr_t & DbPtr)
     : m_DbPtr(DbPtr), terms_set(false)
 {
     if (NULL!=caller_env)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -191,7 +191,6 @@ MoveTask::DoWork()
 
     itr=m_Itr->m_Wrap.get();
 
-//    ++m_Wrap->m_MoveCount;
 //
 // race condition of prefetch clearing db iterator while
 //  async_iterator_move looking at it.
@@ -224,22 +223,6 @@ MoveTask::DoWork()
             }   // if
         }   // if
     }   // if
-
-#if 0
-    // hung iterator debug
-    {
-        struct timeval tv;
-
-        gettimeofday(&tv, NULL);
-
-        // 14400 is 4 hours in seconds ... 60*60*4
-        if ((m_Itr->m_Wrap.m_LastLogReport + 14400) < tv.tv_sec && NULL!=m_Itr->m_Wrap.get())
-        {
-            m_Itr->m_Wrap.LogIterator();
-            m_Itr->m_Wrap.m_LastLogReport=tv.tv_sec;
-        }   // if
-    }
-#endif
 
     // back to normal operation
     if(NULL == itr)

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -69,7 +69,7 @@ class WorkTask : public leveldb::ThreadTask
  public:
     WorkTask(ErlNifEnv *caller_env, ERL_NIF_TERM& caller_ref);
 
-    WorkTask(ErlNifEnv *caller_env, ERL_NIF_TERM& caller_ref, DbObject * DbPtr);
+    WorkTask(ErlNifEnv *caller_env, ERL_NIF_TERM& caller_ref, DbObjectPtr_t & DbPtr);
 
     virtual ~WorkTask();
 
@@ -137,7 +137,7 @@ protected:
 public:
 
     WriteTask(ErlNifEnv* _owner_env, ERL_NIF_TERM _caller_ref,
-                DbObject * _db_handle,
+                DbObjectPtr_t & _db_handle,
                 leveldb::WriteBatch* _batch,
                 leveldb::WriteOptions* _options)
         : WorkTask(_owner_env, _caller_ref, _db_handle),
@@ -207,7 +207,7 @@ protected:
 public:
     GetTask(ErlNifEnv *_caller_env,
             ERL_NIF_TERM _caller_ref,
-            DbObject *_db_handle,
+            DbObjectPtr_t & _db_handle,
             ERL_NIF_TERM _key_term,
             leveldb::ReadOptions &_options)
         : WorkTask(_caller_env, _caller_ref, _db_handle),
@@ -256,7 +256,7 @@ protected:
 public:
     IterTask(ErlNifEnv *_caller_env,
              ERL_NIF_TERM _caller_ref,
-             DbObject *_db_handle,
+             DbObjectPtr_t & _db_handle,
              const bool _keys_only,
              leveldb::ReadOptions &_options)
         : WorkTask(_caller_env, _caller_ref, _db_handle),
@@ -274,7 +274,7 @@ protected:
         void * itr_ptr_ptr;
 
         // NOTE: transfering ownership of options to ItrObject
-        itr_ptr_ptr=ItrObject::CreateItrObject(m_DbPtr.get(), keys_only, options);
+        itr_ptr_ptr=ItrObject::CreateItrObject(m_DbPtr, keys_only, options);
 
         // Copy caller_ref to reuse in future iterator_move calls
         itr_ptr=*(ItrObject**)itr_ptr_ptr;
@@ -311,8 +311,8 @@ public:
 
     // No seek target:
     MoveTask(ErlNifEnv *_caller_env, ERL_NIF_TERM _caller_ref,
-             LevelIteratorWrapper * IterWrap, action_t& _action)
-        : WorkTask(NULL, _caller_ref, IterWrap->m_DbPtr.get()),
+             LevelIteratorWrapperPtr_t & IterWrap, action_t& _action)
+        : WorkTask(NULL, _caller_ref, IterWrap->m_DbPtr),
         m_ItrWrap(IterWrap), action(_action)
     {
         // special case construction
@@ -322,9 +322,9 @@ public:
 
     // With seek target:
     MoveTask(ErlNifEnv *_caller_env, ERL_NIF_TERM _caller_ref,
-             LevelIteratorWrapper * IterWrap, action_t& _action,
+             LevelIteratorWrapperPtr_t & IterWrap, action_t& _action,
              std::string& _seek_target)
-        : WorkTask(NULL, _caller_ref, IterWrap->m_DbPtr.get()),
+        : WorkTask(NULL, _caller_ref, IterWrap->m_DbPtr),
         m_ItrWrap(IterWrap), action(_action),
         seek_target(_seek_target)
         {
@@ -355,7 +355,7 @@ protected:
 public:
 
     CloseTask(ErlNifEnv* _owner_env, ERL_NIF_TERM _caller_ref,
-              DbObject * _db_handle)
+              DbObjectPtr_t & _db_handle)
         : WorkTask(_owner_env, _caller_ref, _db_handle)
     {}
 
@@ -403,7 +403,7 @@ protected:
 public:
 
     ItrCloseTask(ErlNifEnv* _owner_env, ERL_NIF_TERM _caller_ref,
-              ItrObject * _itr_handle)
+              ItrObjectPtr_t & _itr_handle)
         : WorkTask(_owner_env, _caller_ref),
         m_ItrPtr(_itr_handle)
     {}

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -281,9 +281,6 @@ protected:
         itr_ptr->itr_ref_env = enif_alloc_env();
         itr_ptr->itr_ref = enif_make_copy(itr_ptr->itr_ref_env, caller_ref());
 
-        itr_ptr->m_Iter.assign(new LevelIteratorWrapper(itr_ptr, keys_only,
-                                                        options, itr_ptr->itr_ref));
-
         ERL_NIF_TERM result = enif_make_resource(local_env(), itr_ptr_ptr);
 
         // release reference created during CreateItrObject()
@@ -301,7 +298,7 @@ public:
     typedef enum { FIRST, LAST, NEXT, PREV, SEEK, PREFETCH, PREFETCH_STOP } action_t;
 
 protected:
-    ReferencePtr<LevelIteratorWrapper> m_ItrWrap;             //!< access to database, and holds reference
+    ItrObjectPtr_t m_Itr;
 
 public:
     action_t                                       action;
@@ -311,9 +308,9 @@ public:
 
     // No seek target:
     MoveTask(ErlNifEnv *_caller_env, ERL_NIF_TERM _caller_ref,
-             LevelIteratorWrapperPtr_t & IterWrap, action_t& _action)
-        : WorkTask(NULL, _caller_ref, IterWrap->m_DbPtr),
-        m_ItrWrap(IterWrap), action(_action)
+             ItrObjectPtr_t & Iter, action_t& _action)
+        : WorkTask(NULL, _caller_ref, Iter->m_DbPtr),
+        m_Itr(Iter), action(_action)
     {
         // special case construction
         local_env_=NULL;
@@ -322,10 +319,10 @@ public:
 
     // With seek target:
     MoveTask(ErlNifEnv *_caller_env, ERL_NIF_TERM _caller_ref,
-             LevelIteratorWrapperPtr_t & IterWrap, action_t& _action,
+             ItrObjectPtr_t & Iter, action_t& _action,
              std::string& _seek_target)
-        : WorkTask(NULL, _caller_ref, IterWrap->m_DbPtr),
-        m_ItrWrap(IterWrap), action(_action),
+        : WorkTask(NULL, _caller_ref, Iter->m_DbPtr),
+        m_Itr(Iter), action(_action),
         seek_target(_seek_target)
         {
             // special case construction


### PR DESCRIPTION
Switch the few remaining naked pointer uses to reference counted pointers.  This fills some remaining race condition holes (of which one recently seen).

Also, move LevelIteratorWrapper from being a reference counted object.  It is now directly embedded within ItrObject.  This is most likely the source of a recent SegFault.  The ItrObject::Shutdown function released the LevelIteratorWrapper reference pointer which set up a race condition.

Finally, old iterator logging code that was commented out was removed.
