### PR TITLE
Replace msgpack encoding with ttb

### DIFF
--- a/c_src/CmpUtil.cc
+++ b/c_src/CmpUtil.cc
@@ -198,21 +198,21 @@ CmpUtil::parseMap(const char* data, size_t size)
         cmp_object_t key_obj;
 
         if(!cmp_read_object(&cmp, &key_obj) || !cmp_object_is_str(&key_obj))
-	  ThrowRuntimeError("Failed to read key");
+          ThrowRuntimeError("Failed to read key");
 
-	uint32_t len=0;
-	if(!cmp_object_as_str(&key_obj, &len))
-	  ThrowRuntimeError("Error parsing object as a string");
+        uint32_t len=0;
+        if(!cmp_object_as_str(&key_obj, &len))
+          ThrowRuntimeError("Error parsing object as a string");
 
         sBuf.resize(len+1);
         if(!cmp_object_to_str(&cmp, &key_obj, sBuf.getBuf(), len+1))
-	  ThrowRuntimeError("Error reading key string");
+          ThrowRuntimeError("Error reading key string");
 
         std::string key(sBuf.getBuf());
 
-	//------------------------------------------------------------
-	// Next read the field value
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // Next read the field value
+        //------------------------------------------------------------
 
         cmp_object_t obj;
 

--- a/c_src/CmpUtil.h
+++ b/c_src/CmpUtil.h
@@ -2,13 +2,14 @@
 #define ELEVELDB_CMPUTIL_H
 
 /**
- * @file CmpUtil.h
+ * CmpUtil
+ *
+ *   A class for operating on msgpack-encoded data, using the cmp
+ *   library (Original can be found at https://github.com/camgunz/cmp)
  * 
- * Tagged: Wed Sep  9 17:32:28 PDT 2015
+ * Created: Wed Sep  9 17:32:28 PDT 2015
  * 
- * @version: $Revision: $, $Date: $
- * 
- * @author /bin/bash: username: command not found
+ * Original author: eleitch@basho.com
  */
 #include <stdlib.h>
 #include <stddef.h>

--- a/c_src/DataType.h
+++ b/c_src/DataType.h
@@ -43,7 +43,8 @@ namespace eleveldb {
       DOUBLE    =  0x80000,
       STRING    = 0x100000,
       MAP       = 0x200000,
-      TIMESTAMP = 0x400000
+      TIMESTAMP = 0x400000,
+      SMALL_BIG = 0x800000
     };
 
     /**

--- a/c_src/DataType.h
+++ b/c_src/DataType.h
@@ -4,7 +4,7 @@
 /**
  * DataType
  * 
- *   A class for managing data-type scpecifications
+ *   A class for managing data-type specifications
  *
  * Tagged: Wed Sep  9 11:10:10 PDT 2015
  * 

--- a/c_src/DataType.h
+++ b/c_src/DataType.h
@@ -1,16 +1,14 @@
-// $Id: $
-
 #ifndef ELEVELDB_DATATYPE_H
 #define ELEVELDB_DATATYPE_H
 
 /**
- * @file DataType.h
+ * DataType
  * 
+ *   A class for managing data-type scpecifications
+ *
  * Tagged: Wed Sep  9 11:10:10 PDT 2015
  * 
- * @version: $Revision: $, $Date: $
- * 
- * @author /bin/bash: username: command not found
+ * Original author: eleitch@basho.com
  */
 #include <sstream>
 

--- a/c_src/EiUtil.cc
+++ b/c_src/EiUtil.cc
@@ -1,0 +1,1141 @@
+#include "DataType.h"
+#include "EiUtil.h"
+
+#include "exceptionutils.h"
+
+#include <sstream>
+#include <cmath>
+#include <iomanip>
+
+#include <climits>
+
+using namespace std;
+
+using namespace eleveldb;
+
+#define THROW_ERR ThrowRuntimeError("Not a valid EI term")
+
+#define FN_DEF(retType, name, body)             \
+    retType EiUtil::name()                      \
+    {                                           \
+        checkBuf();                             \
+        return name(buf_, &index_);             \
+    }                                           \
+                                                \
+    retType EiUtil::name(char* buf, int* index) \
+    {                                           \
+        body;                                   \
+    }
+    
+//=======================================================================
+// Initialize static maps of conversion functions here
+//=======================================================================
+
+std::map<DataType::Type, EI_CONV_UINT8_FN(*)>  
+EiUtil::uint8ConvMap_ = EiUtil::constructUint8Map();
+
+std::map<DataType::Type, EI_CONV_INT64_FN(*)>  
+EiUtil::int64ConvMap_ = EiUtil::constructInt64Map();
+
+std::map<DataType::Type, EI_CONV_UINT64_FN(*)> 
+EiUtil::uint64ConvMap_ = EiUtil::constructUint64Map();
+
+std::map<DataType::Type, EI_CONV_DOUBLE_FN(*)> 
+EiUtil::doubleConvMap_ = EiUtil::constructDoubleMap();
+
+//=======================================================================
+// A macro for declaring a template convert specialization
+//=======================================================================
+
+#define CONVERT_DECL(typeTo, typeFrom, getName, validation)             \
+    namespace eleveldb {                                                \
+        template<>                                                      \
+        typeTo EiUtil::convert<typeTo, typeFrom>(char* buf, int* index) \
+        {                                                               \
+            typeFrom val;                                               \
+            try {                                                       \
+                val = getName(buf, index);                              \
+                validation;                                             \
+            } catch(...) {                                              \
+                ThrowRuntimeError("Object of type " << typeOf(getType(buf, index), buf, index) << " typestr = " << EiUtil::typeStrOf(buf, index) \
+                                  << " can't be represented as a " << #typeTo << " using " << #getName << " typeFrom = " << #typeFrom); \
+            }                                                           \
+            return (typeTo) val;                                        \
+        }                                                               \
+    }                                                                   \
+                                                                        \
+//=======================================================================
+// A macro for constructing a map of conversion functions to the
+// specified type
+//=======================================================================
+
+#define CONSTRUCT_EI_CONV_MAP(typeTo)                                   \
+    /* int types */                                                     \
+    convMap[DataType::INT64]  = EiUtil::convert<typeTo, int64_t>; \
+                                                                        \
+    /* float types */                                                   \
+    convMap[DataType::DOUBLE] = EiUtil::convert<typeTo, double>; \
+                                                                        \
+    /* Boolean types */                                                 \
+    convMap[DataType::BOOL]   = EiUtil::convert<typeTo, bool>;   
+                                                                        
+EiUtil::EiUtil()
+{
+    initialize(0, 0);
+}
+
+EiUtil::EiUtil(char* buf)
+{
+    initialize(buf, 0);
+}
+
+EiUtil::~EiUtil() {};
+
+void EiUtil::initialize(char* buf, int index)
+{
+    buf_     = buf;
+    index_   = index;
+    version_ = -1;
+
+    version_ = getVersion();
+}
+
+FN_DEF(int, getVersion,
+
+       int version = -1;
+       
+       if(ei_decode_version(buf, index, &version))
+           THROW_ERR;
+       
+       return version;
+    )
+
+FN_DEF(int, getTupleHeader,
+
+       int arity = 0;
+       
+       if(ei_decode_tuple_header(buf, index, &arity))
+           THROW_ERR;
+       
+       return arity;
+    )
+
+FN_DEF(int, getListHeader,
+
+       int arity = 0;
+       
+       if(ei_decode_list_header(buf, index, &arity))
+           THROW_ERR;
+       
+       return arity;
+    )
+
+FN_DEF(ei_term, decodeTerm,
+
+       ei_term term;
+       if(ei_decode_ei_term(buf, index, &term) < 0)
+           THROW_ERR;
+       
+       return term;
+    )
+
+FN_DEF(std::string, printTerm,
+
+       char* s=0;
+       
+       if(ei_s_print_term(&s, buf, index))
+           THROW_ERR;
+       
+       std::string ret(s);
+       
+       if(s)
+           free(s);
+       
+       return ret;
+    )
+
+/**.......................................................................
+ * Return the type of this object
+ */
+FN_DEF(int, getType,
+       int size=0;
+       int type=0;
+        
+       if(ei_get_type(buf, index, &type, &size) < 0)
+           THROW_ERR;
+        
+       return type;
+    )
+        
+/**.......................................................................
+ * Return the size of this object
+ */
+FN_DEF(int, getSize,
+       
+       int size=0;
+       int type=0;
+       
+       if(ei_get_type(buf, index, &type, &size) < 0)
+           THROW_ERR;
+       
+       return size;
+    )
+
+/**.......................................................................
+ * Return true if this is an integer
+ */
+FN_DEF(bool, isInteger,
+       return isInteger(getType(buf, index));
+    )
+
+bool EiUtil::isInteger(int type)
+{
+    switch(type) {
+    case ERL_SMALL_INTEGER_EXT:
+    case ERL_INTEGER_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a float
+ */
+FN_DEF(bool, isFloat,
+       return isFloat(getType(buf, index));
+    )
+
+bool EiUtil::isFloat(int type)
+{
+    switch(type) {
+    case ERL_FLOAT_EXT:
+    case NEW_FLOAT_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is an atom
+ */
+FN_DEF(bool, isAtom,
+       return isAtom(getType(buf, index));
+    )
+
+bool EiUtil::isAtom(int type)
+{ 
+    switch(type) {
+    case ERL_ATOM_EXT:
+    case ERL_SMALL_ATOM_EXT:
+    case ERL_ATOM_UTF8_EXT:
+    case ERL_SMALL_ATOM_UTF8_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a ref
+ */
+FN_DEF(bool, isRef,
+       return isRef(getType(buf, index));
+    )
+
+bool EiUtil::isRef(int type)
+{
+    switch(type) {
+    case ERL_REFERENCE_EXT:
+    case ERL_NEW_REFERENCE_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a port
+ */
+FN_DEF(bool, isPort,
+       return isPort(getType(buf, index));
+    )
+
+bool EiUtil::isPort(int type)
+{
+    switch(type) {
+    case ERL_PORT_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a pid
+ */
+FN_DEF(bool, isPid,
+       return isPid(getType(buf, index));
+    )
+
+bool EiUtil::isPid(int type)
+{
+    switch(type) {
+    case ERL_PID_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is nil
+ */
+FN_DEF(bool, isNil,
+       return isNil(getType(buf, index));
+    )
+
+bool EiUtil::isNil(int type)
+{
+    switch(type) {
+    case ERL_NIL_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a tuple
+ */
+FN_DEF(bool, isTuple,
+       return isTuple(getType(buf, index));
+    )
+
+bool EiUtil::isTuple(int type)
+{
+    switch(type) {
+    case ERL_SMALL_TUPLE_EXT:
+    case ERL_LARGE_TUPLE_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a string
+ */
+FN_DEF(bool, isString,
+       return isString(getType(buf, index));
+    )
+
+bool EiUtil::isString(int type)
+{
+    switch(type) {
+    case ERL_STRING_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a list
+ */
+FN_DEF(bool, isList,
+       return isList(getType(buf, index));
+    )
+
+bool EiUtil::isList(int type)
+{
+    switch(type) {
+    case ERL_LIST_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a binary
+ */
+FN_DEF(bool, isBinary,
+       return isBinary(getType(buf, index));
+    )
+
+bool EiUtil::isBinary(int type)
+{
+    switch(type) {
+    case ERL_BINARY_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a big
+ */
+FN_DEF(bool, isBig,
+       return isBig(getType(buf, index));
+    )
+
+bool EiUtil::isBig(int type)
+{
+    switch(type) {
+    case ERL_SMALL_BIG_EXT:
+    case ERL_LARGE_BIG_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Return true if this is a fun
+ */
+FN_DEF(bool, isFun,
+       return isFun(getType(buf, index));
+    )
+
+bool EiUtil::isFun(int type)
+{
+    switch(type) {
+    case ERL_NEW_FUN_EXT:
+    case ERL_FUN_EXT:
+        return true;
+        break;
+    default:
+        return false;
+        break;
+    }
+}
+
+/**.......................................................................
+ * Get a string representation of the next type
+ */
+FN_DEF(std::string, typeStrOf,
+       return typeStrOf(getType(buf, index));
+    )
+
+std::string EiUtil::typeStrOf(int type)
+{
+    switch(type) {
+    case ERL_SMALL_INTEGER_EXT:
+    case ERL_INTEGER_EXT:
+        return "INT";
+        break;
+    case ERL_FLOAT_EXT:
+    case NEW_FLOAT_EXT:
+        return "FLOAT";
+        break;
+    case ERL_ATOM_EXT:
+    case ERL_SMALL_ATOM_EXT:
+    case ERL_ATOM_UTF8_EXT:
+    case ERL_SMALL_ATOM_UTF8_EXT:
+        return "ATOM";
+        break;
+    case ERL_REFERENCE_EXT:
+    case ERL_NEW_REFERENCE_EXT:
+        return "REF";
+        break;
+    case ERL_PORT_EXT:
+        return "PORT";
+        break;
+    case ERL_PID_EXT:
+        return "PID";
+        break;
+    case ERL_SMALL_TUPLE_EXT:
+    case ERL_LARGE_TUPLE_EXT:
+        return "TUPLE";
+        break;
+    case ERL_NIL_EXT:
+        return "NIL";
+        break;
+    case ERL_STRING_EXT:
+        return "STRING";
+        break;
+    case ERL_LIST_EXT:
+        return "LIST";
+        break;
+    case ERL_BINARY_EXT:
+        return "BINARY";
+        break;
+    case ERL_SMALL_BIG_EXT:
+    case ERL_LARGE_BIG_EXT:
+        return "BIG";
+        break;
+    case ERL_NEW_FUN_EXT:
+    case ERL_FUN_EXT:
+        return "FUN";
+        break;
+    default:
+        return "UNKNOWN";
+        break;
+    }
+}
+
+/**.......................................................................
+ * Get the next type
+ */
+FN_DEF(DataType::Type, typeOf,
+       return typeOf(getType(buf, index), buf, index);
+    )
+
+DataType::Type EiUtil::typeOf(int type, char* buf, int* index)
+{
+    switch(type) {
+    case ERL_SMALL_INTEGER_EXT:
+    case ERL_INTEGER_EXT:
+        return DataType::INT64;
+        break;
+    case ERL_FLOAT_EXT:
+    case NEW_FLOAT_EXT:
+        return DataType::DOUBLE;
+        break;
+    case ERL_ATOM_EXT:
+    case ERL_SMALL_ATOM_EXT:
+    case ERL_ATOM_UTF8_EXT:
+    case ERL_SMALL_ATOM_UTF8_EXT:
+    {
+        if(buf == 0 || index == 0)
+            THROW_ERR;
+
+        int prev = *index;
+        if(isBool(buf, index)) {
+            *index = prev;
+            return DataType::BOOL;
+        } else {
+            return DataType::STRING;
+        }
+    }
+    break;
+    case ERL_STRING_EXT:
+        return DataType::STRING;
+        break;
+    case ERL_BINARY_EXT:
+        return DataType::UCHAR_PTR;
+        break;
+    default:
+        return DataType::UNKNOWN;
+        break;
+    }
+}
+
+FN_DEF(void, skipLastReadObject,
+
+       int size = getSize(buf, index);
+
+       // Skip is the size of the opcode (1), size of the size (4) and
+       // size of the object itself
+
+       *index += size + 4 + 1;
+    )
+
+//=======================================================================
+// Format methods
+//=======================================================================
+
+/**.......................................................................
+ * Format an encoded term for printing
+ */
+FN_DEF(std::string, formatTerm,
+
+       int type = getType(buf, index);
+       
+       if(isAtom(type))
+           return formatAtom(buf, index);
+       
+       if(isInteger(type))
+           return formatInteger(buf, index);
+       
+       if(isFloat(type))
+           return formatFloat(buf, index);
+       
+       if(isTuple(type)) 
+           return formatTuple(buf, index);
+       
+       if(isBinary(type))
+           return formatBinary(buf, index);
+       
+       if(isString(type))
+           return formatString(buf, index);
+       
+       if(isList(type))
+           return formatList(buf, index);
+       
+       if(isNil(type))
+           return "[]";
+       
+       return "?";
+    )
+
+FN_DEF(std::string, formatAtom,
+       
+       std::ostringstream os;
+       os << getAtom(buf, index);
+       return os.str();
+    )
+
+FN_DEF(std::string, formatInteger,
+       
+       std::ostringstream os;
+       os << getLong(buf, index);
+       return os.str();
+    )
+
+FN_DEF(std::string, formatFloat,
+
+       std::ostringstream os;
+       os << getFloat(buf, index);
+       return os.str();
+    )
+
+FN_DEF(std::string, formatTuple,
+
+       int arity = getTupleHeader(buf, index);
+       std::ostringstream os;
+
+       os << "{";
+       for(unsigned iCell=0; iCell < arity; iCell++) {
+           os << formatTerm(buf, index);
+           if(iCell < arity-1)
+               os << ", ";
+       }
+       
+       os << "}";
+       
+       return os.str();
+    )
+
+FN_DEF(std::string, formatList,
+
+       int arity = getListHeader(buf, index);
+       std::ostringstream os;
+
+       os << "[";
+       for(unsigned iCell=0; iCell < arity; iCell++) {
+           os << formatTerm(buf, index);
+           if(iCell < arity-1)
+               os << ", ";
+       }
+       
+       os << "]";
+       
+       return os.str();
+    )
+
+FN_DEF(std::string, formatBinary,
+
+       std::ostringstream os;
+       os << "<<";
+       std::vector<unsigned char> bin = getBinary(buf, index);
+       for(unsigned i=0; i < bin.size(); i++) {
+           os << (int)bin[i];
+           if(i < bin.size()-1)
+               os << ", ";
+       }
+       os << ">>";
+       
+       return os.str();
+    )
+
+FN_DEF(std::string, formatString,
+
+       std::ostringstream os;
+       std::string str = getString(buf, index);
+       os << "\"" << str << "\"";
+       os << " (aka [";
+       for(unsigned i=0; i < str.size(); i++) {
+           os << (int)str[i];
+           if(i < str.size()-1)
+               os << ", ";
+       }
+       os << "])";
+       
+       return os.str();
+    )
+
+//=======================================================================
+// Get methods
+//=======================================================================
+
+FN_DEF(std::string, getString,
+
+       int size = getSize(buf, index);
+       char str[size+1];
+
+       if(ei_decode_string(buf, index, str) < 0)
+           THROW_ERR;
+       
+       return str;
+    )
+
+FN_DEF(std::vector<unsigned char>, getBinary,
+
+       int size = getSize(buf, index);
+       std::vector<unsigned char> ret(size);
+       
+       long len = 0;
+       if(ei_decode_binary(buf, index, (void*)&ret[0], &len))
+           THROW_ERR;
+       
+       return ret;
+    )
+
+FN_DEF(std::string, getAtom,
+
+       char str[MAXATOMLEN+1];
+
+       if(ei_decode_atom(buf, index, str) < 0)
+           THROW_ERR;
+       
+       return str;
+    )
+
+FN_DEF(bool, getBool,
+
+       std::string atom = getAtom(buf, index);
+       return atom == "false" || atom == "true";
+    )
+
+FN_DEF(bool, isBool,
+
+       if(isAtom(buf, index)) {
+           std::string atom = getAtom(buf, index);
+           return atom == "false" || atom == "true";
+       }
+       
+       return false;
+    )
+
+FN_DEF(double, getFloat,
+       return getDouble(buf, index);
+    )
+
+FN_DEF(double, getDouble,
+
+       double val;
+       if(ei_decode_double(buf, index, &val) < 0)
+           THROW_ERR;
+       
+       return val;
+    )
+
+FN_DEF(long, getLong,
+
+       long val;
+       if(ei_decode_long(buf, index, &val) < 0)
+           THROW_ERR;
+
+       return val;
+    )
+
+FN_DEF(unsigned long, getUlong,
+
+       unsigned long val;
+       if(ei_decode_ulong(buf, index, &val) < 0)
+           THROW_ERR;
+       
+       return val;
+    )
+
+FN_DEF(int64_t, getInt64,
+
+       long long val;
+       if(ei_decode_longlong(buf, index, &val) < 0)
+           THROW_ERR;
+
+       return val;
+    )
+
+FN_DEF(uint64_t, getUint64,
+
+       unsigned long long val;
+       if(ei_decode_ulonglong(buf, index, &val) < 0)
+           THROW_ERR;
+
+       return val;
+    )
+
+/**.......................................................................
+ * Parse a map encoded as a msgpack object into component keys and
+ * datatypes
+ */
+std::map<std::string, DataType::Type> EiUtil::parseMap()
+{
+    checkBuf();
+    return parseMap(buf_, &index_);
+}
+
+std::map<std::string, DataType::Type> EiUtil::parseMap(char* buf, int* index)
+{
+    std::map<std::string, DataType::Type> keyValMap;
+
+    if(!isList(buf, index))
+        ThrowRuntimeError("Binary data must contain a term_to_binary() formatted list");
+    
+    unsigned nVal = getListHeader(buf, index);
+    
+    for(unsigned int i=0; i < nVal; i++) {
+        
+        if(!isTuple(buf, index) || getTupleHeader(buf, index) != 2) {
+            ThrowRuntimeError("List must consist of {field, val} tuples: ");
+        }
+        
+        std::vector<unsigned char> bin = getBinary(buf, index);
+        std::string str((char*)&bin[0]);
+        
+        keyValMap[str] = typeOf(buf, index);
+
+        // Read past
+        
+        formatTerm(buf, index);
+    }
+    
+    return keyValMap;
+}
+
+/**.......................................................................
+ * Print a map of keys + datatypes
+ */
+void EiUtil::printMap(std::map<std::string, DataType::Type>& keyValMap)
+{
+    for(std::map<std::string, DataType::Type>::iterator iter = keyValMap.begin();
+        iter != keyValMap.end(); iter++) {
+        COUT(iter->first << " " << iter->second);
+    }
+}
+                      
+/**.......................................................................
+ * Return a pointer to the data for the next object, and its size
+ */
+unsigned char* EiUtil::getDataPtr(char* buf, int* index, size_t& size, bool includeMarker)
+{
+    // If we are including the opcode and size prefix, the 'size' of
+    // the data is the size returned by getSize(), plus the size of
+    // the opcode and prefix (1 + 4)
+
+    size = getSize(buf, index)  + (includeMarker ? 5 : 0);
+
+    // If we are including the opcode and prefix, just return the
+    // pointer at the current location.  Else advance by the opcode
+    // and prefix length
+
+    return (unsigned char*)(buf + *index + (includeMarker ? 0 : 5));
+}
+                                                 
+void EiUtil::checkBuf() 
+{
+    if(!buf_)
+        ThrowRuntimeError("No buffer has been set");
+}
+
+//=======================================================================
+// Templatized convert specializations
+//=======================================================================
+
+//------------------------------------------------------------
+// Conversions to uint8_t
+//------------------------------------------------------------
+
+CONVERT_DECL(uint8_t, bool, getBool,
+             return val;
+    );
+
+CONVERT_DECL(uint8_t, uint8_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(uint8_t, int8_t, getLong, 
+             if(val >= 0)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, int16_t, getLong, 
+             if(val >= 0 && val <= UCHAR_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, uint16_t, getUlong, 
+             if(val <= UCHAR_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, int32_t, getLong,
+             if(val >= 0 && val <= UCHAR_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, uint32_t, getUlong,
+             if(val <= UCHAR_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, int64_t, getInt64,
+             if(val >= 0 && val <= UCHAR_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, uint64_t, getUint64,
+             if(val <= UCHAR_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, float, getDouble,
+             if(val >= 0.0 && val <= (float)UCHAR_MAX && !(fabs(val - (uint8_t)val) > 0.0))
+                 return val;
+    );
+
+CONVERT_DECL(uint8_t, double, getDouble,
+             if(val >= 0.0 && val <= (double)UCHAR_MAX && !(fabs(val - (uint8_t)val) > 0.0))
+                 return val;
+    );
+
+//------------------------------------------------------------
+// Conversions to int64_t
+//------------------------------------------------------------
+
+CONVERT_DECL(int64_t, bool, getBool,
+             return val;
+    );
+
+CONVERT_DECL(int64_t, uint8_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(int64_t, int8_t, getLong, 
+             return val;
+    );
+
+CONVERT_DECL(int64_t, int16_t, getLong, 
+             return val;
+    );
+
+CONVERT_DECL(int64_t, uint16_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(int64_t, int32_t, getLong,
+             return val;
+    );
+
+CONVERT_DECL(int64_t, uint32_t, getUlong,
+             return val;
+    );
+
+CONVERT_DECL(int64_t, int64_t, getInt64,
+             return val;
+    );
+
+CONVERT_DECL(int64_t, uint64_t, getUint64,
+             if(val <= LLONG_MAX)
+                 return val;
+    );
+
+CONVERT_DECL(int64_t, float, getDouble,
+             if(val <= (float)LLONG_MAX && val >= (float)LLONG_MIN && !(fabs(val - (int64_t)val) > 0.0))
+                 return val;
+    );
+
+CONVERT_DECL(int64_t, double, getDouble,
+             if(val <= (double)LLONG_MAX && val >= (double)LLONG_MIN && !(fabs(val - (int64_t)val) > 0.0))
+                 return val;
+    );
+
+
+//------------------------------------------------------------
+// Conversions to uint64_t
+//------------------------------------------------------------
+
+CONVERT_DECL(uint64_t, bool, getBool,
+             return val;
+    );
+
+CONVERT_DECL(uint64_t, uint8_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(uint64_t, int8_t, getLong, 
+             if(val >= 0)
+                 return val;
+    );
+
+CONVERT_DECL(uint64_t, int16_t, getLong, 
+             if(val >= 0)
+                 return val;
+    );
+
+CONVERT_DECL(uint64_t, uint16_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(uint64_t, int32_t, getLong,
+             if(val >= 0)
+                 return val;
+    );
+
+CONVERT_DECL(uint64_t, uint32_t, getUlong,
+             return val;
+    );
+
+CONVERT_DECL(uint64_t, int64_t, getInt64,
+             if(val >= 0)
+                 return val;
+    );
+
+CONVERT_DECL(uint64_t, uint64_t, getUint64,
+             return val;
+    );
+
+CONVERT_DECL(uint64_t, float, getDouble,
+             if(val >= 0.0 && val <= (float)ULONG_MAX && !(fabs(val - (uint64_t)val) > 0.0))
+                 return val;
+    );
+
+CONVERT_DECL(uint64_t, double, getDouble,
+             if(val >= 0.0 && val <= (double)ULONG_MAX && !(fabs(val - (uint64_t)val) > 0.0))
+                 return val;
+    );
+
+//------------------------------------------------------------
+// Conversions to double
+//------------------------------------------------------------
+
+CONVERT_DECL(double, bool, getBool,
+             return val;
+    );
+
+CONVERT_DECL(double, uint8_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(double, int8_t, getLong, 
+             return val;
+    );
+
+CONVERT_DECL(double, int16_t, getLong, 
+             return val;
+    );
+
+CONVERT_DECL(double, uint16_t, getUlong, 
+             return val;
+    );
+
+CONVERT_DECL(double, int32_t, getLong,
+             return val;
+    );
+
+CONVERT_DECL(double, uint32_t, getUlong,
+             return val;
+    );
+
+CONVERT_DECL(double, int64_t, getInt64,
+             return val;
+    );
+
+CONVERT_DECL(double, uint64_t, getUint64,
+             return val;
+    );
+
+CONVERT_DECL(double, float, getDouble,
+             return val;
+    );
+
+CONVERT_DECL(double, double, getDouble,
+             return val;
+    );
+
+uint8_t EiUtil::objectToUint8(char* buf, int* index)
+{
+    DataType::Type type = typeOf(getType(buf, index), buf, index);
+    if(EiUtil::uint8ConvMap_.find(type) != EiUtil::uint8ConvMap_.end())
+        return EiUtil::uint8ConvMap_[type](buf, index);
+    else 
+        ThrowRuntimeError("Object of type " << typeStrOf(buf, index) << " can't be converted to a uint8_t type");
+    return 0;
+}
+
+int64_t EiUtil::objectToInt64(char* buf, int* index)
+{
+    DataType::Type type = typeOf(getType(buf, index), buf, index);
+    if(EiUtil::int64ConvMap_.find(type) != EiUtil::int64ConvMap_.end())
+        return EiUtil::int64ConvMap_[type](buf, index);
+    else 
+        ThrowRuntimeError("Object of type " << typeStrOf(buf, index) << " can't be converted to a int64_t type");
+    return 0;
+}
+
+uint64_t EiUtil::objectToUint64(char* buf, int* index)
+{
+    DataType::Type type = typeOf(getType(buf, index), buf, index);
+    if(EiUtil::uint64ConvMap_.find(type) != EiUtil::uint64ConvMap_.end())
+        return EiUtil::uint64ConvMap_[type](buf, index);
+    else 
+        ThrowRuntimeError("Object of type " << typeStrOf(buf, index) << " can't be converted to a uint64_t type");
+    return 0;
+}
+
+double EiUtil::objectToDouble(char* buf, int* index)
+{
+    DataType::Type type = typeOf(getType(buf, index), buf, index);
+    if(EiUtil::doubleConvMap_.find(type) != EiUtil::doubleConvMap_.end())
+        return EiUtil::doubleConvMap_[type](buf, index);
+    else 
+        ThrowRuntimeError("Object of type " << typeStrOf(buf, index) << " can't be converted to a double type");
+    return 0;
+}
+
+std::map<DataType::Type, EI_CONV_UINT8_FN(*)>  EiUtil::constructUint8Map()
+{
+    std::map<DataType::Type, EI_CONV_UINT8_FN(*)> convMap;
+    CONSTRUCT_EI_CONV_MAP(uint8_t);
+    return convMap;
+}
+
+std::map<DataType::Type, EI_CONV_INT64_FN(*)>  EiUtil::constructInt64Map()
+{
+    std::map<DataType::Type, EI_CONV_INT64_FN(*)> convMap;
+    CONSTRUCT_EI_CONV_MAP(int64_t);
+    return convMap;
+}
+
+std::map<DataType::Type, EI_CONV_UINT64_FN(*)>  EiUtil::constructUint64Map()
+{
+    std::map<DataType::Type, EI_CONV_UINT64_FN(*)> convMap;
+    CONSTRUCT_EI_CONV_MAP(uint64_t);
+    return convMap;
+}
+
+std::map<DataType::Type, EI_CONV_DOUBLE_FN(*)>  EiUtil::constructDoubleMap()
+{
+    std::map<DataType::Type, EI_CONV_DOUBLE_FN(*)> convMap;
+    CONSTRUCT_EI_CONV_MAP(double);
+    return convMap;
+}

--- a/c_src/EiUtil.cc
+++ b/c_src/EiUtil.cc
@@ -1003,7 +1003,7 @@ FN_DEF(std::string, formatTuple,
        std::ostringstream os;
 
        os << "{";
-       for(unsigned iCell=0; iCell < arity; iCell++) {
+       for(int iCell=0; iCell < arity; iCell++) {
            os << formatTerm(buf, index);
            if(iCell < arity-1)
                os << ", ";
@@ -1028,7 +1028,7 @@ FN_DEF(std::string, formatList,
        std::ostringstream os;
 
        os << "[";
-       for(unsigned iCell=0; iCell < arity; iCell++) {
+       for(int iCell=0; iCell < arity; iCell++) {
            os << formatTerm(buf, index);
            if(iCell < arity-1)
                os << ", ";
@@ -1052,7 +1052,7 @@ FN_DEF(std::string, formatBinary,
        std::ostringstream os;
        os << "<<";
        std::vector<unsigned char> bin = getBinary(buf, index);
-       for(unsigned i=0; i < bin.size(); i++) {
+       for(int i=0; i < bin.size(); i++) {
            os << (int)bin[i];
            if(i < bin.size()-1)
                os << ", ";
@@ -1068,7 +1068,7 @@ FN_DEF(std::string, formatString,
        std::string str = getString(buf, index);
        os << "\"" << str << "\"";
        os << " (aka [";
-       for(unsigned i=0; i < str.size(); i++) {
+       for(int i=0; i < str.size(); i++) {
            os << (int)str[i];
            if(i < str.size()-1)
                os << ", ";

--- a/c_src/EiUtil.cc
+++ b/c_src/EiUtil.cc
@@ -1018,7 +1018,7 @@ FN_DEF(void, skipTuple,
 
        int arity = getTupleHeader(buf, index);
 
-       for(unsigned iCell=0; iCell < arity; iCell++)
+       for(int iCell=0; iCell < arity; iCell++)
            skipLastReadObject(buf, index);
     )
 
@@ -1043,7 +1043,7 @@ FN_DEF(void, skipList,
 
        int arity = getListHeader(buf, index);
 
-       for(unsigned iCell=0; iCell < arity; iCell++)
+       for(int iCell=0; iCell < arity; iCell++)
            skipLastReadObject(buf, index);
     )
 
@@ -1052,9 +1052,10 @@ FN_DEF(std::string, formatBinary,
        std::ostringstream os;
        os << "<<";
        std::vector<unsigned char> bin = getBinary(buf, index);
-       for(int i=0; i < bin.size(); i++) {
+       unsigned int size = bin.size();
+       for(unsigned int i=0; i < size; i++) {
            os << (int)bin[i];
-           if(i < bin.size()-1)
+           if(i < size-1)
                os << ", ";
        }
        os << ">>";
@@ -1068,9 +1069,10 @@ FN_DEF(std::string, formatString,
        std::string str = getString(buf, index);
        os << "\"" << str << "\"";
        os << " (aka [";
-       for(int i=0; i < str.size(); i++) {
+       unsigned int size=str.size();
+       for(unsigned int i=0; i < size; i++) {
            os << (int)str[i];
-           if(i < str.size()-1)
+           if(i < size-1)
                os << ", ";
        }
        os << "])";

--- a/c_src/EiUtil.cc
+++ b/c_src/EiUtil.cc
@@ -1004,9 +1004,11 @@ FN_DEF(std::string, formatTuple,
 
        os << "{";
        for(int iCell=0; iCell < arity; iCell++) {
-           os << formatTerm(buf, index);
-           if(iCell < arity-1)
+
+           if(iCell > 0)
                os << ", ";
+
+           os << formatTerm(buf, index);
        }
        
        os << "}";
@@ -1029,11 +1031,12 @@ FN_DEF(std::string, formatList,
 
        os << "[";
        for(int iCell=0; iCell < arity; iCell++) {
-           os << formatTerm(buf, index);
-           if(iCell < arity-1)
+
+           if(iCell > 0)
                os << ", ";
+
+           os << formatTerm(buf, index);
        }
-       
        os << "]";
        
        return os.str();
@@ -1052,11 +1055,12 @@ FN_DEF(std::string, formatBinary,
        std::ostringstream os;
        os << "<<";
        std::vector<unsigned char> bin = getBinary(buf, index);
-       unsigned int size = bin.size();
-       for(unsigned int i=0; i < size; i++) {
-           os << (int)bin[i];
-           if(i < size-1)
+       for(unsigned int i=0; i < bin.size(); i++) {
+
+           if(i > 0)
                os << ", ";
+
+           os << (int)bin[i];
        }
        os << ">>";
        
@@ -1069,13 +1073,11 @@ FN_DEF(std::string, formatString,
        std::string str = getString(buf, index);
        os << "\"" << str << "\"";
        os << " (aka [";
-       unsigned int size=str.size();
-       for(unsigned int i=0; i < size; i++) {
+       for(unsigned int i=0; i < str.size(); i++) {
 
-           if(i > 0) {
+           if(i > 0)
                os << ", ";
-           }
-           
+
            os << (int)str[i];
        }
        os << "])";

--- a/c_src/EiUtil.cc
+++ b/c_src/EiUtil.cc
@@ -1071,9 +1071,12 @@ FN_DEF(std::string, formatString,
        os << " (aka [";
        unsigned int size=str.size();
        for(unsigned int i=0; i < size; i++) {
-           os << (int)str[i];
-           if(i < size-1)
+
+           if(i > 0) {
                os << ", ";
+           }
+           
+           os << (int)str[i];
        }
        os << "])";
        

--- a/c_src/EiUtil.cc
+++ b/c_src/EiUtil.cc
@@ -841,6 +841,31 @@ FN_DEF(std::string, getBinaryAsString,
        return sBuf.getString();
     )
 
+FN_DEF(std::string, getBinaryAsStringEml,
+
+       //------------------------------------------------------------
+       // binary is opcode, followed by 4-byte size, followed by bytes
+       //------------------------------------------------------------
+
+       unsigned int size = getUint(buf + *index + 1);
+
+       // ei_decode_binary() copies exactly size bytes into the return
+       // buffer.  If we are interpreting the data as a string, the
+       // return buffer must be NULL terminated, else the conversion
+       // to a string will not be well defined
+       
+       StringBuf sBuf(size+1);
+       char* bufPtr = sBuf.getBuf();
+       bufPtr[size] = '\0';
+       
+       for(unsigned i=0; i < size; i++)
+           bufPtr[i] = buf[*index + 5 + i];
+
+       *index += 5 + size;
+       
+       return sBuf.getString();
+    )
+
 FN_DEF(std::string, getAtom,
 
        char str[MAXATOMLEN+1];

--- a/c_src/EiUtil.h
+++ b/c_src/EiUtil.h
@@ -1,0 +1,167 @@
+#ifndef ELEVELDB_EIUTIL_H
+#define ELEVELDB_EIUTIL_H
+
+/**
+ * @file EiUtil.h
+ * 
+ * Tagged: Wed Sep  9 17:32:28 PDT 2015
+ * 
+ * @version: $Revision: $, $Date: $
+ * 
+ * @author /bin/bash: username: command not found
+ */
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <map>
+#include <vector>
+
+#include "ei.h"
+
+#include "DataType.h"
+
+#define EI_CONV_UINT8_FN(fn)  uint8_t  (fn)(char* buf, int* index)
+#define EI_CONV_INT64_FN(fn)  int64_t  (fn)(char* buf, int* index)
+#define EI_CONV_UINT64_FN(fn) uint64_t (fn)(char* buf, int* index)
+#define EI_CONV_DOUBLE_FN(fn) double   (fn)(char* buf, int* index)
+
+#define FN_DECL(retType, name) \
+        retType name();                         \
+        static retType name(char* buf, int* index);
+
+namespace eleveldb {
+
+    class EiUtil {
+    public:
+        
+        /**
+         * Constructor.
+         */
+        EiUtil();
+        EiUtil(char* buf);
+
+        /**
+         * Destructor.
+         */
+        virtual ~EiUtil();
+
+        void initialize(char* buf, int index);
+
+        FN_DECL(std::string, printTerm);
+        FN_DECL(std::string, formatTerm);
+
+        FN_DECL(int, getVersion);
+        FN_DECL(int, getTupleHeader);
+        FN_DECL(int, getListHeader);
+        
+        FN_DECL(ei_term, decodeTerm);
+        
+        FN_DECL(int, getType);
+        FN_DECL(int, getSize);
+
+        FN_DECL(bool, isInteger);
+        FN_DECL(bool, isFloat);
+        FN_DECL(bool, isAtom);
+        FN_DECL(bool, isBool);
+        FN_DECL(bool, isRef);
+        FN_DECL(bool, isPort);
+        FN_DECL(bool, isPid);
+        FN_DECL(bool, isNil);
+        FN_DECL(bool, isTuple);
+        FN_DECL(bool, isString);
+        FN_DECL(bool, isList);
+        FN_DECL(bool, isBinary);
+        FN_DECL(bool, isBig);
+        FN_DECL(bool, isFun);
+        
+        static bool isInteger(int type);
+        static bool isFloat(int type);
+        static bool isAtom(int type);
+        static bool isRef(int type);
+        static bool isPort(int type);
+        static bool isPid(int type);
+        static bool isNil(int type);
+        static bool isTuple(int type);
+        static bool isString(int type);
+        static bool isList(int type);
+        static bool isBinary(int type);
+        static bool isBig(int type);
+        static bool isFun(int type);
+        
+        FN_DECL(std::string, typeStrOf);
+        FN_DECL(DataType::Type, typeOf);
+
+        static std::string typeStrOf(int type);
+        static DataType::Type typeOf(int type, char* buf, int* index);
+
+        static unsigned char* getDataPtr(char* buf, int* index, size_t& size, 
+                                         bool includeMarker);
+
+        FN_DECL(bool,          getBool);
+        FN_DECL(std::string,   getAtom);
+        FN_DECL(std::string,   getString);
+        FN_DECL(double,        getDouble);
+        FN_DECL(double,        getFloat);
+        FN_DECL(long,          getLong);
+        FN_DECL(unsigned long, getUlong);
+        FN_DECL(int64_t,       getInt64);
+        FN_DECL(uint64_t,      getUint64);
+        FN_DECL(std::vector<unsigned, char> getBinary);
+        
+        FN_DECL(std::string, formatAtom);
+        FN_DECL(std::string, formatInteger);
+        FN_DECL(std::string, formatFloat);
+        FN_DECL(std::string, formatTuple);
+        FN_DECL(std::string, formatBinary);
+        FN_DECL(std::string, formatString);
+        FN_DECL(std::string, formatList);
+        
+        FN_DECL(void, skipLastReadObject);
+        
+        std::map<std::string, DataType::Type> parseMap();
+        static std::map<std::string, DataType::Type> parseMap(char* buf, int* index);
+
+        // Print a map of field/type pairs
+
+        static void printMap(std::map<std::string, DataType::Type>& keyValMap);
+
+        // Return a map of conversion functions
+
+        static std::map<DataType::Type, EI_CONV_UINT8_FN(*)>  constructUint8Map();
+        static std::map<DataType::Type, EI_CONV_INT64_FN(*)>  constructInt64Map();
+        static std::map<DataType::Type, EI_CONV_UINT64_FN(*)> constructUint64Map();
+        static std::map<DataType::Type, EI_CONV_DOUBLE_FN(*)> constructDoubleMap();
+
+        // Static maps of conversion functions
+
+        static std::map<DataType::Type, EI_CONV_UINT8_FN(*)>  uint8ConvMap_;
+        static std::map<DataType::Type, EI_CONV_INT64_FN(*)>  int64ConvMap_;
+        static std::map<DataType::Type, EI_CONV_UINT64_FN(*)> uint64ConvMap_;
+        static std::map<DataType::Type, EI_CONV_DOUBLE_FN(*)> doubleConvMap_;
+
+        // Object conversion functions
+
+        static uint8_t  objectToUint8(char* buf, int* index);
+        static int64_t  objectToInt64(char* buf, int* index);
+        static uint64_t objectToUint64(char* buf, int* index);
+        static double   objectToDouble(char* buf, int* index);
+        
+        // Templatized type-conversion functions
+
+        template<typename typeTo, typename typeFrom> 
+            static typeTo convert(char* buf, int* index);
+
+    private:
+
+        void checkBuf();
+
+        char* buf_;
+        int index_;
+        int version_;
+
+    }; // End class EiUtil
+    
+} // End namespace eleveldb
+
+#endif // End #ifndefELEVELDB_EIUTIL_H

--- a/c_src/EiUtil.h
+++ b/c_src/EiUtil.h
@@ -128,6 +128,7 @@ namespace eleveldb {
         FN_DECL(uint64_t,      getBigAsUint64);
         FN_DECL(std::vector<unsigned, char> getBinary);
         FN_DECL(std::string, getBinaryAsString);
+        FN_DECL(std::string, getBinaryAsStringEml);
         
         FN_DECL(std::string, formatAtom);
         FN_DECL(std::string, formatInteger);

--- a/c_src/EiUtil.h
+++ b/c_src/EiUtil.h
@@ -141,7 +141,11 @@ namespace eleveldb {
         FN_DECL(void, skipTuple);
         FN_DECL(void, skipList);
         FN_DECL(void, skipLastReadObject);
-        
+
+        static void skipNext(char* buf, int* index);
+        static unsigned int getUint(char* buf);
+        static unsigned short getUshort(char* buf);
+
         std::map<std::string, DataType::Type> parseMap();
         static std::map<std::string, DataType::Type> parseMap(char* buf, int* index);
 

--- a/c_src/EiUtil.h
+++ b/c_src/EiUtil.h
@@ -2,13 +2,14 @@
 #define ELEVELDB_EIUTIL_H
 
 /**
- * @file EiUtil.h
+ * EiUtil
+ *
+ *   A class for operating on erlang term_to_binary-encoded data,
+ *   using the ei library (see http://erlang.org/doc/man/ei.html)
  * 
- * Tagged: Wed Sep  9 17:32:28 PDT 2015
+ * Created: Wed Sep  9 17:32:28 PDT 2015
  * 
- * @version: $Revision: $, $Date: $
- * 
- * @author /bin/bash: username: command not found
+ * Original author: eleitch@basho.com
  */
 #include <stdlib.h>
 #include <stddef.h>

--- a/c_src/EiUtil.h
+++ b/c_src/EiUtil.h
@@ -34,6 +34,19 @@ namespace eleveldb {
 
     class EiUtil {
     public:
+
+        struct Big {
+
+            bool isSigned_;
+            unsigned size_;
+            uint64_t val_;
+
+            Big() {
+                isSigned_ = false;
+                size_     = 0;
+                val_      = 0;
+            };
+        };
         
         /**
          * Constructor.
@@ -72,7 +85,11 @@ namespace eleveldb {
         FN_DECL(bool, isString);
         FN_DECL(bool, isList);
         FN_DECL(bool, isBinary);
+
         FN_DECL(bool, isBig);
+        FN_DECL(bool, canBeUint64);
+        static bool isBig(char* buf, int* index, unsigned& size, bool& isSigned);
+        
         FN_DECL(bool, isFun);
         
         static bool isInteger(int type);
@@ -107,16 +124,22 @@ namespace eleveldb {
         FN_DECL(unsigned long, getUlong);
         FN_DECL(int64_t,       getInt64);
         FN_DECL(uint64_t,      getUint64);
+        FN_DECL(Big,           getBig);
+        FN_DECL(uint64_t,      getBigAsUint64);
         FN_DECL(std::vector<unsigned, char> getBinary);
+        FN_DECL(std::string, getBinaryAsString);
         
         FN_DECL(std::string, formatAtom);
         FN_DECL(std::string, formatInteger);
+        FN_DECL(std::string, formatBig);
         FN_DECL(std::string, formatFloat);
         FN_DECL(std::string, formatTuple);
         FN_DECL(std::string, formatBinary);
         FN_DECL(std::string, formatString);
         FN_DECL(std::string, formatList);
-        
+
+        FN_DECL(void, skipTuple);
+        FN_DECL(void, skipList);
         FN_DECL(void, skipLastReadObject);
         
         std::map<std::string, DataType::Type> parseMap();

--- a/c_src/EiUtil.h
+++ b/c_src/EiUtil.h
@@ -35,8 +35,18 @@ namespace eleveldb {
     class EiUtil {
     public:
 
+        //------------------------------------------------------------
+        // What I'm calling Big is a type encoded by TTB, but for
+        // which no encoding is implemented in the ei library.
+        // 
+        // It can contain a positive or negative value, and can store
+        // ints as an arbitrary number of bytes.
+        //
+        // This struct is for managing up to 8-byte integers encoded
+        // as a big
+        //------------------------------------------------------------
+        
         struct Big {
-
             bool isSigned_;
             unsigned size_;
             uint64_t val_;
@@ -127,8 +137,8 @@ namespace eleveldb {
         FN_DECL(Big,           getBig);
         FN_DECL(uint64_t,      getBigAsUint64);
         FN_DECL(std::vector<unsigned, char> getBinary);
-        FN_DECL(std::string, getBinaryAsString);
-        FN_DECL(std::string, getBinaryAsStringEml);
+        FN_DECL(std::string,   getBinaryAsString);
+        FN_DECL(std::string,   getBinaryAsStringEml);
         
         FN_DECL(std::string, formatAtom);
         FN_DECL(std::string, formatInteger);
@@ -144,8 +154,6 @@ namespace eleveldb {
         FN_DECL(void, skipLastReadObject);
 
         static void skipNext(char* buf, int* index);
-        static unsigned int getUint(char* buf);
-        static unsigned short getUshort(char* buf);
 
         std::map<std::string, DataType::Type> parseMap();
         static std::map<std::string, DataType::Type> parseMap(char* buf, int* index);

--- a/c_src/Encoding.cc
+++ b/c_src/Encoding.cc
@@ -49,6 +49,21 @@ std::string Encoding::encodingAtom(Encoding::Type type)
     }
 }
 
+unsigned char Encoding::encodingByte(Encoding::Type type)
+{
+    switch(type) {
+    case Encoding::ERLANG:
+        return ERLANG_MAGIC;
+        break;
+    case Encoding::MSGPACK:
+        return MSGPACK_MAGIC;
+        break;
+    default:
+        return 0;
+        break;
+    }
+}
+
 Encoding::Type Encoding::typeOf(std::string str, bool doThrow)
 {
     if(str == encodingAtom(ERLANG))

--- a/c_src/Encoding.h
+++ b/c_src/Encoding.h
@@ -2,13 +2,14 @@
 #define ELEVELDB_ENCODING_H
 
 /**
- * @file Encoding.h
+ * Encoding
  * 
- * Tagged: Mon Sep 14 11:36:04 PDT 2015
+ *   A class for managing valid encodings used in writing TS records
+ *   to disk.
+ *
+ * Created: Mon Sep 14 11:36:04 PDT 2015
  * 
- * @version: $Revision: $, $Date: $
- * 
- * @author /bin/bash: username: command not found
+ * Original author: eleitch@basho.com
  */
 #include <sstream>
 

--- a/c_src/Encoding.h
+++ b/c_src/Encoding.h
@@ -12,6 +12,9 @@
  */
 #include <sstream>
 
+#define MSGPACK_MAGIC 2
+#define ERLANG_MAGIC  0
+
 namespace eleveldb {
 
     class Encoding {
@@ -35,6 +38,7 @@ namespace eleveldb {
         virtual ~Encoding();
 
         static std::string encodingAtom(Encoding::Type type);
+        static unsigned char encodingByte(Encoding::Type type);
         static Type typeOf(std::string str, bool doThrow);
 
         friend std::ostream& operator<<(std::ostream& os,  Encoding::Type type);

--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -1129,6 +1129,11 @@ std::string ErlUtil::formatBinary(ErlNifEnv* env, ERL_NIF_TERM term)
     return os.str();
 }
 
+std::string ErlUtil::formatBinary(char* buf, size_t size)
+{
+    return formatBinary((unsigned char*) buf, size);
+}
+
 std::string ErlUtil::formatBinary(unsigned char* buf, size_t size)
 {
     std::ostringstream os;

--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -1159,9 +1159,12 @@ std::string ErlUtil::formatBinary(ErlNifEnv* env, ERL_NIF_TERM term)
 
     os << "<<";
     for(unsigned iByte=0; iByte < bin.size; iByte++) {
-        os << (int)bin.data[iByte];
-        if(iByte < bin.size-1)
+
+        if(iByte > 0) {
             os << ", ";
+        }
+
+        os << (int)bin.data[iByte];
     }
     os << ">>";
 

--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -1027,7 +1027,7 @@ std::string ErlUtil::formatTerm(ErlNifEnv* env, ERL_NIF_TERM term)
     }
 
     if(isBinary(env, term)) {
-        return formatBinary(env, term);
+        return formatAsString(env, term);
     }
 
     if(isString(env, term)) {
@@ -1084,6 +1084,14 @@ std::string ErlUtil::formatNumber(ErlNifEnv* env, ERL_NIF_TERM term)
     }
 
     return "?";
+}
+
+std::string ErlUtil::formatAsString(ErlNifEnv* env, ERL_NIF_TERM term)
+{
+    std::ostringstream os;
+    os << "\"" << getAsString(env, term) << "\"";
+
+    return os.str();
 }
 
 std::string ErlUtil::formatString(ErlNifEnv* env, ERL_NIF_TERM term)

--- a/c_src/ErlUtil.cc
+++ b/c_src/ErlUtil.cc
@@ -1140,9 +1140,11 @@ std::string ErlUtil::formatList(ErlNifEnv* env, ERL_NIF_TERM term)
 
     os << "[";
     for(unsigned iCell=0; iCell < cells.size(); iCell++) {
-        os << formatTerm(env, cells[iCell]);
-        if(iCell < cells.size()-1)
+
+        if(iCell > 0)
             os << ", ";
+
+        os << formatTerm(env, cells[iCell]);
     }
     os << "]";
 
@@ -1160,9 +1162,8 @@ std::string ErlUtil::formatBinary(ErlNifEnv* env, ERL_NIF_TERM term)
     os << "<<";
     for(unsigned iByte=0; iByte < bin.size; iByte++) {
 
-        if(iByte > 0) {
+        if(iByte > 0)
             os << ", ";
-        }
 
         os << (int)bin.data[iByte];
     }
@@ -1182,9 +1183,11 @@ std::string ErlUtil::formatBinary(unsigned char* buf, size_t size)
 
     os << "<<";
     for(unsigned iByte=0; iByte < size; iByte++) {
-        os << (int)buf[iByte];
-        if(iByte < size-1)
+
+        if(iByte > 0)
             os << ", ";
+
+        os << (int)buf[iByte];
     }
     os << ">>";
 
@@ -1214,11 +1217,12 @@ std::string ErlUtil::formatTupleVec(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& c
     
     os << "{";
     for(unsigned iCell=0; iCell < cells.size(); iCell++) {
-        os << formatTerm(env, cells[iCell]);
-        if(iCell < cells.size()-1)
-            os << ", ";
-    }
 
+        if(iCell > 0)
+            os << ", ";
+
+        os << formatTerm(env, cells[iCell]);
+    }
     os << "}";
 
     return os.str();

--- a/c_src/ErlUtil.h
+++ b/c_src/ErlUtil.h
@@ -137,7 +137,8 @@ namespace eleveldb {
         static std::string formatBinary(ErlNifEnv* env, ERL_NIF_TERM term);
 
         static std::string formatBinary(unsigned char* buf, size_t size);
-
+        static std::string formatBinary(char* buf, size_t size);
+        
         static std::string formatList(  ErlNifEnv* env, ERL_NIF_TERM term);
         static std::string formatNumber(ErlNifEnv* env, ERL_NIF_TERM term);
         static std::string formatString(ErlNifEnv* env, ERL_NIF_TERM term);

--- a/c_src/ErlUtil.h
+++ b/c_src/ErlUtil.h
@@ -142,6 +142,7 @@ namespace eleveldb {
         static std::string formatList(  ErlNifEnv* env, ERL_NIF_TERM term);
         static std::string formatNumber(ErlNifEnv* env, ERL_NIF_TERM term);
         static std::string formatString(ErlNifEnv* env, ERL_NIF_TERM term);
+        static std::string formatAsString(ErlNifEnv* env, ERL_NIF_TERM term);
         static std::string formatTuple( ErlNifEnv* env, ERL_NIF_TERM term);
         static std::string formatTupleVec(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& tuple);
 

--- a/c_src/ErlUtil.h
+++ b/c_src/ErlUtil.h
@@ -1,16 +1,16 @@
-// $Id: $
-
 #ifndef ELEVELDB_ERLUTIL_H
 #define ELEVELDB_ERLUTIL_H
 
 /**
- * @file ErlUtil.h
+ * ErlUtil
+ *
+ *   A class for manipulating erlang terms passed across the NIF
+ *   interface, based on the erl_nif library library (see
+ *   http://erlang.org/doc/man/erl_nif.html)
  * 
- * Tagged: Wed Sep  2 14:46:45 PDT 2015
+ * Created: Wed Sep  9 17:32:28 PDT 2015
  * 
- * @version: $Revision: $, $Date: $
- * 
- * @author /bin/bash: username: command not found
+ * Original author: eleitch@basho.com
  */
 #include "erl_nif.h"
 #include "workitems.h"

--- a/c_src/StringBuf.cc
+++ b/c_src/StringBuf.cc
@@ -4,7 +4,7 @@
 
 using namespace eleveldb;
 
-/**.......................................................................                                                                  
+/**.......................................................................
  * Bare constructor just calls initialize()
  */
 StringBuf::StringBuf()
@@ -12,9 +12,9 @@ StringBuf::StringBuf()
     initialize();
 }
 
-/**.......................................................................                                                                  
- * Constructor initializes size to minBufSize_, and sets internal buf                                                                       
- * pointer to point to the stack buffer                                                                                                     
+/**.......................................................................
+ * Constructor initializes size to minBufSize_, and sets internal buf
+ * pointer to point to the stack buffer
  */
 StringBuf::StringBuf(size_t size)
 {
@@ -22,9 +22,9 @@ StringBuf::StringBuf(size_t size)
     resize(size);
 }
 
-/**.......................................................................                                                                  
- * Initializes size to minBufSize_, and sets internal buf pointer to                                                                        
- * point to the stack buffer                                                                                                                
+/**.......................................................................
+ * Initializes size to minBufSize_, and sets internal buf pointer to
+ * point to the stack buffer
  */
 void StringBuf::initialize()
 {
@@ -74,8 +74,8 @@ void StringBuf::copyAsString(char* buf, size_t size)
     dataSize_ = size;
 }
 
-/**.......................................................................                                                                  
- * Destructor frees any allocated memory, and resets to init state                                                                          
+/**.......................................................................
+ * Destructor frees any allocated memory, and resets to init state
  */
 StringBuf::~StringBuf()
 {

--- a/c_src/StringBuf.cc
+++ b/c_src/StringBuf.cc
@@ -106,3 +106,8 @@ void StringBuf::resize(size_t size)
         bufSize_    = size;
     }
 }
+
+std::string StringBuf::getString()
+{
+    return bufPtr_;
+}

--- a/c_src/StringBuf.h
+++ b/c_src/StringBuf.h
@@ -61,6 +61,11 @@ namespace eleveldb {
 
         char*  getBuf();
 
+        // Return a string representation of the internal buffer
+        // (assumed to be null-terminated)
+        
+        std::string getString();
+        
     private:
 
         void initialize();

--- a/c_src/StringBuf.h
+++ b/c_src/StringBuf.h
@@ -1,18 +1,15 @@
-// $Id: $
-
 #ifndef ELEVELDB_STRINGBUF_H
 #define ELEVELDB_STRINGBUF_H
 
 #define STRING_BUF_MIN_SIZE 1024
 
 /**
- * @file StringBuf.h
+ * StringBuf
  * 
- * Tagged: Tue Oct 20 16:30:05 PDT 2015
- * 
- * @version: $Revision: $, $Date: $
- * 
- * @author /bin/bash: username: command not found
+ *   A class for managing a char buffer, initially allocated on the
+ *   stack, but grown from the heap if resized beyond a fixed limit.
+ *
+ * Original author: eleitch@basho.com
  */
 #include <stdlib.h>
 #include <stddef.h>

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -61,28 +61,6 @@
 
 #include "leveldb/atomics.h"
 
-#define DOTEST(type, einame, index) {                 \
-        index=0;                                      \
-        type uli = 1467563367600, ruli=0;             \
-        char buf[1000];                               \
-        ei_encode_##einame(buf, &index, uli);            \
-        index=0;                                        \
-        ei_decode_##einame(buf, &index, &ruli);          \
-        COUT("uli = " << uli << " ruli = " << ruli << " index = " << index);  \
-        index=1;                                                        \
-        COUT("Type is: " << EiUtil::getType(buf, &index));              \
-        COUT("Type is: " << (char)EiUtil::getType(buf, &index));        \
-        COUT("Type is: " << EiUtil::typeOf(buf, &index));               \
-    }
-
-#define EXTEST(type, einame, data, index) {                              \
-        index=0;                                                        \
-        type ruli=0;                                                    \
-        int status = ei_decode_##einame((char*)&data[0], &index, &ruli);     \
-        COUT("status = " << status << " ruli = " << ruli);              \
-    }
-
-
 static ErlNifFunc nif_funcs[] =
 {
     {"async_close", 2, eleveldb::async_close},
@@ -837,7 +815,7 @@ decodeei(
             index += 5;
 
             for(unsigned i=0; i < nel; i++) 
-                EiUtil::skipNext((char*)&data[0], &index);
+                EiUtil::skipLastReadObject((char*)&data[0], &index);
 
             // Now format the next item
             

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -85,7 +85,6 @@ static ErlNifFunc nif_funcs[] =
     {"streaming_stop", 1, eleveldb::streaming_stop},
 
     {"current_usec",    0, eleveldb::currentMicroSeconds},
-    {"print_to_stdout", 1, eleveldb::printToStdout},
 };
 
 
@@ -1274,8 +1273,6 @@ streaming_start(ErlNifEnv * env,
     const ERL_NIF_TERM end_key_term     = argv[2];
     const ERL_NIF_TERM options_list     = argv[3];
 
-    STDOUT("Inside SS with opts = " << ErlUtil::formatTerm(env, options_list));
-
     ReferencePtr<DbObject> db_ptr;
     db_ptr.assign(DbObject::RetrieveDbObject(env, db_ref));
 
@@ -1392,16 +1389,6 @@ currentMicroSeconds(
 {
   return enif_make_int64(env, getCurrentMicroSeconds());
 } // currentMicroSeconds
-
-ERL_NIF_TERM
-printToStdout(
-    ErlNifEnv* env,
-    int argc,
-    const ERL_NIF_TERM argv[])
-{
-    STDOUT(ErlUtil::formatTerm(env, argv[0]));
-    return ATOM_OK;
-}
 
 /**
  * HEY YOU ... please make async

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -158,9 +158,6 @@ ERL_NIF_TERM ATOM_STREAMING_END;
 ERL_NIF_TERM ATOM_STREAMING_ERROR;
 ERL_NIF_TERM ATOM_LIMIT;
 ERL_NIF_TERM ATOM_UNDEFINED;
-ERL_NIF_TERM ATOM_ENCODING;
-ERL_NIF_TERM ATOM_ERLANG_ENCODING;
-ERL_NIF_TERM ATOM_MSGPACK_ENCODING;
 ERL_NIF_TERM ATOM_CACHE_OBJECT_WARMING;
 ERL_NIF_TERM ATOM_EXPIRY_ENABLED;
 ERL_NIF_TERM ATOM_EXPIRY_MINUTES;
@@ -614,15 +611,8 @@ ERL_NIF_TERM parse_streaming_option(ErlNifEnv* env, ERL_NIF_TERM item,
                 opts.limit = limit;
 
             //------------------------------------------------------------
-            // ATOM_ENCODING specifies which extractor to use
-            //------------------------------------------------------------
-
-        } else if (option[0] == eleveldb::ATOM_ENCODING) {
-            opts.encodingType_ = Encoding::typeOf(ErlUtil::getString(env, option[1]), true);
-
-            //------------------------------------------------------------
             // ATOM_RANGE_FILTER specifies a filter.  Defer parsing
-            // this until we read the first key
+            // this until we read the first key.
             //------------------------------------------------------------
 
         } else if (option[0] == eleveldb::ATOM_RANGE_FILTER) {
@@ -1643,9 +1633,6 @@ try
     ATOM(eleveldb::ATOM_STREAMING_ERROR, "streaming_error");
     ATOM(eleveldb::ATOM_LIMIT, "limit");
     ATOM(eleveldb::ATOM_UNDEFINED, "undefined");
-    ATOM(eleveldb::ATOM_ENCODING, "encoding");
-    ATOM(eleveldb::ATOM_ERLANG_ENCODING,  Encoding::encodingAtom(Encoding::ERLANG).c_str());
-    ATOM(eleveldb::ATOM_MSGPACK_ENCODING, Encoding::encodingAtom(Encoding::MSGPACK).c_str());
     ATOM(eleveldb::ATOM_CACHE_OBJECT_WARMING, "cache_object_warming");
     ATOM(eleveldb::ATOM_EXPIRY_ENABLED, "expiry_enabled");
     ATOM(eleveldb::ATOM_EXPIRY_MINUTES, "expiry_minutes");

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -1273,6 +1273,8 @@ streaming_start(ErlNifEnv * env,
     const ERL_NIF_TERM end_key_term     = argv[2];
     const ERL_NIF_TERM options_list     = argv[3];
 
+    STDOUT("Inside SS with opts = " << ErlUtil::formatTerm(env, options_list));
+
     ReferencePtr<DbObject> db_ptr;
     db_ptr.assign(DbObject::RetrieveDbObject(env, db_ref));
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -84,7 +84,8 @@ static ErlNifFunc nif_funcs[] =
     {"streaming_ack", 2, eleveldb::streaming_ack},
     {"streaming_stop", 1, eleveldb::streaming_stop},
 
-    {"current_usec",   0, eleveldb::currentMicroSeconds},
+    {"current_usec",    0, eleveldb::currentMicroSeconds},
+    {"print_to_stdout", 1, eleveldb::printToStdout},
 };
 
 
@@ -1391,6 +1392,16 @@ currentMicroSeconds(
 {
   return enif_make_int64(env, getCurrentMicroSeconds());
 } // currentMicroSeconds
+
+ERL_NIF_TERM
+printToStdout(
+    ErlNifEnv* env,
+    int argc,
+    const ERL_NIF_TERM argv[])
+{
+    STDOUT(ErlUtil::formatTerm(env, argv[0]));
+    return ATOM_OK;
+}
 
 /**
  * HEY YOU ... please make async

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -1271,6 +1271,8 @@ streaming_start(ErlNifEnv * env,
     const ERL_NIF_TERM end_key_term     = argv[2];
     const ERL_NIF_TERM options_list     = argv[3];
 
+    FOUT("Streaming start with range filter: " << ErlUtil::formatTerm(env, options_list));
+    
     ReferencePtr<DbObject> db_ptr;
     db_ptr.assign(DbObject::RetrieveDbObject(env, db_ref));
 

--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -84,8 +84,6 @@ static ErlNifFunc nif_funcs[] =
     {"streaming_stop", 1, eleveldb::streaming_stop},
 
     {"current_usec",   0, eleveldb::currentMicroSeconds},
-
-    {"decodeei",   1, eleveldb::decodeei},
 };
 
 
@@ -778,58 +776,6 @@ async_open(
 
 }   // async_open
 
-ERL_NIF_TERM
-decodeei(
-    ErlNifEnv* env,
-    int argc,
-    const ERL_NIF_TERM argv[])
-{
-    // We allow decodeei to be called with the following semantics
-    //
-    // {Bin, decode}
-    // {Bin, skip, Nrecord}
-   
-    try {
-
-        std::vector<ERL_NIF_TERM> cells = ErlUtil::getTupleCells(env, argv[0]);
-        
-        std::vector<unsigned char> data = ErlUtil::getBinary(env, cells[0]);
-        std::string op = ErlUtil::getAtom(env, cells[1]);
-
-        if(op == "decode") {
-
-            int index=1;
-            COUT(EiUtil::formatTerm((char*)&data[0], &index));
-
-        } else if(op == "skip") {
-
-            unsigned nel = ErlUtil::getValAsUint32(env, cells[2]);
-
-            int index=1;
-            char* buf = (char*)&data[0];
-            int opcode = (int)((unsigned char)buf[index]);
-
-            if(opcode != 108) 
-                ThrowRuntimeError("Not a list");
-
-            index += 5;
-
-            for(unsigned i=0; i < nel; i++) 
-                EiUtil::skipLastReadObject((char*)&data[0], &index);
-
-            // Now format the next item
-            
-            COUT(EiUtil::formatTerm((char*)&data[0], &index));
-        }
-        
-        return ATOM_OK;
-        
-    } catch(std::runtime_error& err) {
-        COUT("Caught an error: " << err.what());
-        return ATOM_ERROR;
-    }
-}
-    
 ERL_NIF_TERM
 async_write(
     ErlNifEnv* env,

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -58,6 +58,8 @@ ERL_NIF_TERM streaming_stop(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 ERL_NIF_TERM currentMicroSeconds(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
+ERL_NIF_TERM decodeei(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+
 } // namespace eleveldb
 
 

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -57,9 +57,6 @@ ERL_NIF_TERM streaming_ack(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM streaming_stop(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM currentMicroSeconds(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-
-ERL_NIF_TERM decodeei(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-
 } // namespace eleveldb
 
 

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -57,6 +57,7 @@ ERL_NIF_TERM streaming_ack(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM streaming_stop(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM currentMicroSeconds(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM printToStdout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 } // namespace eleveldb
 

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -57,7 +57,6 @@ ERL_NIF_TERM streaming_ack(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM streaming_stop(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM currentMicroSeconds(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
-ERL_NIF_TERM printToStdout(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 } // namespace eleveldb
 

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -57,6 +57,7 @@ ERL_NIF_TERM streaming_ack(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM streaming_stop(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM currentMicroSeconds(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+
 } // namespace eleveldb
 
 

--- a/c_src/exceptionutils.h
+++ b/c_src/exceptionutils.h
@@ -8,7 +8,7 @@
 
 #define ThrowRuntimeError(text) {\
     std::ostringstream _macroOs;\
-    _macroOs << text;		\
+    _macroOs << text;           \
     throw std::runtime_error(_macroOs.str());\
   }
 
@@ -19,7 +19,7 @@
 
 #define COUT(text) {\
     std::ostringstream _macroOs;\
-    _macroOs << text;		\
+    _macroOs << text;           \
     std::cout << '\r' << _macroOs.str() << std::endl << "\r";\
 }
 

--- a/c_src/exceptionutils.h
+++ b/c_src/exceptionutils.h
@@ -30,4 +30,11 @@
         outfile.close();                                                \
     }
 
+#define STDOUT(text) {                                                    \
+        std::fstream outfile;                                           \
+        outfile.open("/dev/stdout", std::fstream::out|std::fstream::app); \
+        outfile << text << std::endl;                                   \
+        outfile.close();                                                \
+    }
+
 #endif

--- a/c_src/exceptionutils.h
+++ b/c_src/exceptionutils.h
@@ -2,6 +2,7 @@
 #define EXCEPTIONUTILS_H
 
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <stdexcept>
 
@@ -16,4 +17,12 @@
     _macroOs << text;		\
     std::cout << '\r' << _macroOs.str() << std::endl << "\r";\
 }
+
+#define FOUT(text) {                                                    \
+        std::fstream outfile;                                           \
+        outfile.open("/tmp/eleveldb.txt", std::fstream::out|std::fstream::app); \
+        outfile << text << std::endl;                                   \
+        outfile.close();                                                \
+    }
+
 #endif

--- a/c_src/exceptionutils.h
+++ b/c_src/exceptionutils.h
@@ -30,11 +30,4 @@
         outfile.close();                                                \
     }
 
-#define STDOUT(text) {                                                    \
-        std::fstream outfile;                                           \
-        outfile.open("/dev/stdout", std::fstream::out|std::fstream::app); \
-        outfile << text << std::endl;                                   \
-        outfile.close();                                                \
-    }
-
 #endif

--- a/c_src/exceptionutils.h
+++ b/c_src/exceptionutils.h
@@ -12,6 +12,11 @@
     throw std::runtime_error(_macroOs.str());\
   }
 
+//------------------------------------------------------------
+// Macros not used in production code, but useful for debugging, so
+// I'm leaving them here.
+//------------------------------------------------------------
+
 #define COUT(text) {\
     std::ostringstream _macroOs;\
     _macroOs << text;		\

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -1,6 +1,6 @@
-#include "ErlUtil.h"
 #include "CmpUtil.h"
 #include "EiUtil.h"
+#include "ErlUtil.h"
 #include "StringBuf.h"
 
 #include "cmp.h"

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -922,7 +922,8 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
             //------------------------------------------------------------
 
         } else {
-            EiUtil::skipLastReadObject(data, &index);
+//            EiUtil::skipLastReadObject(data, &index);
+            EiUtil::skipNext(data, &index);
         }
     }
 }

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -435,7 +435,7 @@ bool Extractor::riakObjectContentsCanBeParsed(const char* data, size_t size, uns
  * contents portion of an encoded riak object
  */
 void Extractor::getToRiakObjectContents(const char* data, size_t size, 
-					const char** contentsPtr, size_t& contentsSize) 
+                                        const char** contentsPtr, size_t& contentsSize) 
 {
     const char* ptr = data;
 
@@ -560,8 +560,8 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
         if(!cmp_read_object(&cmp_, &key_obj) || !cmp_object_is_str(&key_obj))
             ThrowRuntimeError("Failed to read key");
 
-	uint32_t len=0;
-	if(!cmp_object_as_str(&key_obj, &len))
+        uint32_t len=0;
+        if(!cmp_object_as_str(&key_obj, &len))
             ThrowRuntimeError("Error parsing object as a string");
 
         sBuf.resize(len+1);
@@ -570,19 +570,19 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
 
         std::string key(sBuf.getBuf());
 
-	//------------------------------------------------------------
-	// Next read the field value
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // Next read the field value
+        //------------------------------------------------------------
 
         cmp_object_t obj;
 
         if(!cmp_read_object(&cmp_, &obj))
             ThrowRuntimeError("Unable to read value for field " << key);
 
-	//------------------------------------------------------------
-	// If this field is one of the fields in our filter, try to
-	// process the value
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // If this field is one of the fields in our filter, try to
+        // process the value
+        //------------------------------------------------------------
 
         if(expr_fields_.find(key) != expr_fields_.end()) {
 
@@ -816,14 +816,14 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
 
         std::string key = EiUtil::getBinaryAsStringEml(data, &index);
 
-	//------------------------------------------------------------
-	// Next up is the field value
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // Next up is the field value
+        //------------------------------------------------------------
 
-	//------------------------------------------------------------
-	// If this field is one of the fields in our filter, try to
-	// process the value
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // If this field is one of the fields in our filter, try to
+        // process the value
+        //------------------------------------------------------------
 
         if(expr_fields_.find(key) != expr_fields_.end()) {
 

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -1,5 +1,6 @@
-#include "CmpUtil.h"
 #include "ErlUtil.h"
+#include "CmpUtil.h"
+#include "EiUtil.h"
 #include "StringBuf.h"
 
 #include "cmp.h"
@@ -11,8 +12,6 @@
 
 #include <arpa/inet.h>
 #include <inttypes.h>
-
-#define MSGPACK_MAGIC 2
 
 using namespace eleveldb;
 
@@ -375,7 +374,7 @@ DataType::Type Extractor::cTypeOf(ErlNifEnv* env, ERL_NIF_TERM tuple, bool throw
  * Given the start of a key data binary, return the start and size of the
  * contents portion of an encoded riak object
  */
-bool Extractor::riakObjectContentsCanBeParsed(const char* data, size_t size)
+bool Extractor::riakObjectContentsCanBeParsed(const char* data, size_t size, unsigned char& encMagic)
 {
     const char* ptr = data;
 
@@ -419,9 +418,9 @@ bool Extractor::riakObjectContentsCanBeParsed(const char* data, size_t size)
     // Check that it is
     //------------------------------------------------------------
 
-    unsigned char encMagic = (*ptr++);
+    encMagic = (*ptr++);
 
-    if(encMagic != MSGPACK_MAGIC)
+    if(!(encMagic == MSGPACK_MAGIC || encMagic == ERLANG_MAGIC))
         return false;
 
     return true;
@@ -492,23 +491,36 @@ void Extractor::getToRiakObjectContents(const char* data, size_t size,
      contentsSize = valLen;
 }
 
-//=======================================================================
-// Methods of Msgpack extractor
-//=======================================================================
+/**.......................................................................
+ * Extract relevant fields from the data array into the expression tree
+ */
+void Extractor::parseRiakObjectTypes(const char* data, size_t size) 
+{
+    const char* contentsPtr=0;
+    size_t contentsSize=0;
+    getToRiakObjectContents(data, size, &contentsPtr, contentsSize);
 
-ExtractorMsgpack::ExtractorMsgpack() {}
-ExtractorMsgpack::~ExtractorMsgpack() {}
+    parseTypes(contentsPtr, contentsSize);
+}
 
 /**.......................................................................
  * Extract relevant fields from a riak object into the expression tree
  */
-void ExtractorMsgpack::extractRiakObject(const char* data, size_t size, ExpressionNode<bool>* root) 
+void Extractor::extractRiakObject(const char* data, size_t size, ExpressionNode<bool>* root) 
 {
     const char* contentsPtr=0;
     size_t contentsSize=0;
     getToRiakObjectContents(data, size, &contentsPtr, contentsSize);
     extract(contentsPtr, contentsSize, root);
 }
+
+
+//=======================================================================
+// Methods of Msgpack extractor
+//=======================================================================
+
+ExtractorMsgpack::ExtractorMsgpack() {}
+ExtractorMsgpack::~ExtractorMsgpack() {}
 
 void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<bool>* root) 
 {
@@ -597,28 +609,24 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
                     switch (specType) {
                     case DataType::UINT8:
                     {
-                        //COUT("Converting " << CmpUtil::typeStrOf(&obj) << " to uint8");
                         uint8_t val = CmpUtil::objectToUint8(&obj);
                         root->set_value(key, (void*)&val, specType);
                     }
                     break;
                     case DataType::INT64:
                     {
-                        //COUT("Converting " << CmpUtil::typeStrOf(&obj) << " to int64");
                         int64_t val = CmpUtil::objectToInt64(&obj);
                         root->set_value(key, (void*)&val, specType);
                     }
                     break;
                     case DataType::UINT64:
                     {
-                        //COUT("Converting " << CmpUtil::typeStrOf(&obj) << " to uint64");
                         uint64_t val = CmpUtil::objectToUint64(&obj);
                         root->set_value(key, (void*)&val, DataType::UINT64);
                     }
                     break;
                     case DataType::DOUBLE:
                     {
-                        //COUT("Converting " << CmpUtil::typeStrOf(&obj) << " to double");
                         double val = CmpUtil::objectToDouble(&obj);
                         root->set_value(key, (void*)&val, specType);
                     }
@@ -648,7 +656,6 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
 
                     case DataType::ANY:
                     {
-                        //COUT("Converting " << CmpUtil::typeStrOf(&obj) << " to binary (any)");
                         setBinaryVal(root, key, &ma, &cmp_, &obj, true);
                     }
                     break;
@@ -660,7 +667,6 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
 
                     default:
                     {
-                        //COUT("Converting " << CmpUtil::typeStrOf(&obj) << " to binary");
                         setBinaryVal(root, key, &ma, &cmp_, &obj, false);
                     }
                     break;
@@ -715,30 +721,312 @@ void ExtractorMsgpack::setBinaryVal(ExpressionNode<bool>* root,
 }
 
 /**.......................................................................
- * Extract relevant fields from the data array into the expression tree
- */
-void ExtractorMsgpack::parseRiakObjectTypes(const char* data, size_t size) 
-{
-    const char* contentsPtr=0;
-    size_t contentsSize=0;
-    getToRiakObjectContents(data, size, &contentsPtr, contentsSize);
-
-    parseTypes(contentsPtr, contentsSize);
-}
-
-/**.......................................................................
  * Read through a msgpack-encoded object, parsing the data types for
  * each field we encounter
  */
 void ExtractorMsgpack::parseTypes(const char* data, size_t size) 
 {
     field_types_ = CmpUtil::parseMap(data, size);
-
-#if 0
-    CmpUtil::printMap(field_types_);
-    printMap(field_types_);
-#endif
-
     typesParsed_ = true;
 }
 
+//=======================================================================
+// Methods of ExtractorErlang
+//=======================================================================
+
+ExtractorErlang::ExtractorErlang() 
+{
+}
+
+ExtractorErlang::~ExtractorErlang() 
+{
+}
+
+std::map<std::string, eleveldb::DataType::Type> 
+ExtractorErlang::parseMap(const char* data, size_t size) 
+{
+    // In Ei format, first byte is a version
+
+    int index=1; 
+    return EiUtil::parseMap((char*)data, &index);
+}
+
+void ExtractorErlang::parseTypes(const char* data, size_t size) 
+{
+    field_types_ = parseMap(data, size);
+    typesParsed_ = true;
+}
+
+/**.......................................................................
+ * Set a binary value decoded from erlang as the expression value
+ */
+void ExtractorErlang::setBinaryVal(ExpressionNode<bool>* root, std::string& key, 
+                                   char* buf, int* index,
+                                   bool includeMarker)
+{
+    size_t size=0;
+    unsigned char* ptr = EiUtil::getDataPtr(buf, index, size, includeMarker);
+
+    root->set_value(key, &ptr, DataType::UCHAR_PTR, size);
+
+    // And increment the pointer as if we read it
+
+    *index += includeMarker ? size : size + 5;
+}
+
+void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>* root) 
+{
+    root->clear();
+
+    // First byte is the version
+
+    int index=1;
+    char* data = (char*)ptr;
+
+    if(!EiUtil::isList(data, &index)) {
+        ThrowRuntimeError("Binary data must contain a term_to_binary() formatted list");
+    }
+
+    unsigned nVal = EiUtil::getListHeader(data, &index);
+
+    //------------------------------------------------------------
+    // Iterate over the object, looking for fields
+    //------------------------------------------------------------
+
+    for(unsigned int i=0; i < nVal; i++) {
+
+        if(!EiUtil::isTuple(data, &index) || EiUtil::getTupleHeader(data, &index) != 2) {
+            ThrowRuntimeError("List must consist of {field, val} tuples: " << std::endl
+                              << ErlUtil::formatBinary(data, size));
+        }
+
+        //------------------------------------------------------------
+        // First read the field key
+        //------------------------------------------------------------
+
+        std::vector<unsigned char> bin = EiUtil::getBinary(data, &index);
+        std::string key((char*)&bin[0]);
+
+	//------------------------------------------------------------
+	// Next up is the field value
+	//------------------------------------------------------------
+
+	//------------------------------------------------------------
+	// If this field is one of the fields in our filter, try to
+	// process the value
+	//------------------------------------------------------------
+
+        if(expr_fields_.find(key) != expr_fields_.end()) {
+
+            DataType::Type specType = expr_fields_[key];
+
+            //------------------------------------------------------------
+            // If there is no value for this field, do nothing
+            //------------------------------------------------------------
+            
+            if(EiUtil::isNil(data, &index)) {
+                continue;
+            
+                //------------------------------------------------------------
+                // Else set the appropriate value type for this field.
+                //
+                // We have to check the type every time because encoding
+                // can in priciple convert data of the same erlang type
+                // into different packed types.
+                //
+                // Thus we check the type specification for this field,
+                // and convert from whichever type was chosen to the
+                // appropriate type for our filter.
+                //------------------------------------------------------------
+                
+            } else {
+                
+                try {
+                
+                    switch (specType) {
+                    case DataType::UINT8:
+                    {
+                        uint8_t val = EiUtil::objectToUint8(data, &index);
+                        root->set_value(key, (void*)&val, specType);
+                    }
+                    break;
+                    case DataType::INT64:
+                    {
+                        int64_t val = EiUtil::objectToInt64(data, &index);
+                        root->set_value(key, (void*)&val, specType);
+                    }
+                    break;
+                    case DataType::UINT64:
+                    {
+                        uint64_t val = EiUtil::objectToUint64(data, &index);
+                        root->set_value(key, (void*)&val, DataType::UINT64);
+                    }
+                    break;
+                    case DataType::DOUBLE:
+                    {
+                        double val = EiUtil::objectToDouble(data, &index);
+                        root->set_value(key, (void*)&val, specType);
+                    }
+                    break;
+
+                    //------------------------------------------------------------
+                    // Type ANY means that the data for this field are
+                    // opaque.  We don't try to interpret these, but treat
+                    // them as binary blobs.  
+                    //
+                    // Because the value that they might be compared
+                    // against in a filter could also be a msgpack-ed
+                    // blob, we store the initial msgpack marker as well
+                    // as the data contents.  
+                    //
+                    // This means that comparisons like:
+                    //
+                    //   {const, msgpack:pack([1,2,{<<"junk">>}], [{format, jsx}])}
+                    //
+                    // with 
+                    // 
+                    //   {field, "field1", any}
+                    // 
+                    // will work correctly if field1 contains the same blob that
+                    // is msgpack formatted
+                    //------------------------------------------------------------
+
+                    case DataType::ANY:
+                    {
+                        setBinaryVal(root, key,  data, &index, true);
+                    }
+                    break;
+
+                    //------------------------------------------------------------
+                    // Other types that are identified as binary will be
+                    // unpacked as binaries and the contents compared
+                    //------------------------------------------------------------
+
+                    default:
+                    {
+                        setBinaryVal(root, key, data, &index, false);
+                    }
+                    break;
+                    }
+
+                } catch(std::runtime_error& err) {
+                    ThrowRuntimeError(err.what() 
+                                      << std::endl << "While processing field: " << key);
+                }
+
+            }
+
+            //------------------------------------------------------------
+            // Skip over the last object if we didn't parse its value
+            //------------------------------------------------------------
+
+        } else {
+
+            // TODO: Need a skip function like CmpUtil here.
+            // formatTerm() is a proxy since it reads over the data,
+            // but it does other things too that we don't need
+
+            EiUtil::formatTerm(data, &index);
+        }
+    }
+}
+
+//=======================================================================
+// Methods of ExtractorMap
+//=======================================================================
+
+/**.......................................................................
+ * Constructor just allocates extractors for all known encodings, and
+ * initializes them
+ */
+ExtractorMap::ExtractorMap()
+{
+    //------------------------------------------------------------
+    // Since we now allow for multiple encoding types in the data
+    // stream, we simply allocate a map of extractors for all
+    // known encodings
+    //------------------------------------------------------------
+    
+    map_[Encoding::encodingByte(Encoding::MSGPACK)] = new ExtractorMsgpack();
+    map_[Encoding::encodingByte(Encoding::ERLANG)]  = new ExtractorErlang();
+
+    //------------------------------------------------------------
+    // Since the data types are now passed with the filter, we no
+    // longer need to wait to decode some data to determine them,
+    // so parse the filter up-front.  Note that to use the code
+    // as-is, we need to set extractor_->typesParsed_ to true as
+    // if we had parsed the datatypes
+    //------------------------------------------------------------
+    
+    for(std::map<unsigned char, Extractor*>::iterator iter=map_.begin(); iter != map_.end(); iter++)
+        iter->second->typesParsed_ = true;
+}
+
+/**.......................................................................
+ * Destructor frees allocated extractors
+ */
+ExtractorMap::~ExtractorMap()
+{
+    for(std::map<unsigned char, Extractor*>::iterator iter=map_.begin(); iter != map_.end(); iter++) {
+        if(iter->second) {
+            delete iter->second;
+            iter->second = 0;
+        }
+    }
+}
+
+/**.......................................................................
+ * Return the extractor for the requested encoding flag.  This method
+ * is called from a loop that checks first for valid encodings, and
+ * therefore does not separately check if the flag is in the map.
+ */
+Extractor* ExtractorMap::extractorNoCheck(unsigned char encodingFlag)
+{
+    return map_[encodingFlag];
+}
+
+//-----------------------------------------------------------------------
+// Overloaded methods of Extractor class that perform the indicated
+// operations over all extractors managed by this object
+//-----------------------------------------------------------------------
+
+void ExtractorMap::add_field(std::string field)
+{
+    for(std::map<unsigned char, Extractor*>::iterator iter=map_.begin(); iter != map_.end(); iter++)
+        iter->second->add_field(field);
+}
+
+DataType::Type ExtractorMap::cTypeOf(ErlNifEnv* env,
+                                     ERL_NIF_TERM operand1, 
+                                     ERL_NIF_TERM operand2,
+                                     bool throwIfInvalid)
+{
+    DataType::Type type = DataType::UNKNOWN;
+
+    for(std::map<unsigned char, Extractor*>::iterator iter=map_.begin(); iter != map_.end(); iter++)
+        type = iter->second->cTypeOf(env, operand1, operand2, throwIfInvalid);
+
+    return type;
+}
+
+DataType::Type ExtractorMap::cTypeOf(ErlNifEnv* env,
+                                     ERL_NIF_TERM operand,
+                                     bool throwIfInvalid)
+{
+    DataType::Type type = DataType::UNKNOWN;
+
+    for(std::map<unsigned char, Extractor*>::iterator iter=map_.begin(); iter != map_.end(); iter++)
+        type = iter->second->cTypeOf(env, operand, throwIfInvalid);
+
+    return type;
+}
+
+DataType::Type ExtractorMap::cTypeOf(std::string field)
+{
+    DataType::Type type = DataType::UNKNOWN;
+
+    for(std::map<unsigned char, Extractor*>::iterator iter=map_.begin(); iter != map_.end(); iter++)
+        type = iter->second->cTypeOf(field);
+
+    return type;
+}

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -478,8 +478,8 @@ void Extractor::getToRiakObjectContents(const char* data, size_t size,
 
     unsigned char encMagic = (*ptr++);
 
-    if(encMagic != MSGPACK_MAGIC)
-        ThrowRuntimeError("This is not msgpack-encoded data");
+    if(!(encMagic == MSGPACK_MAGIC || encMagic == ERLANG_MAGIC))
+        ThrowRuntimeError("This record uses an unsupported encoding");
 
     //------------------------------------------------------------
     // Set the passed ptr pointing to the start of the contents for this
@@ -582,6 +582,8 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
 
             DataType::Type specType = expr_fields_[key];
 
+            FOUT("Found field with specType = " << specType);
+            
             //------------------------------------------------------------
             // If there is no value for this field, do nothing
             //------------------------------------------------------------
@@ -604,6 +606,8 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
 
             } else {
 
+                FOUT("Trying to erxtract val");
+
                 try {
 
                     switch (specType) {
@@ -617,6 +621,7 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
                     {
                         int64_t val = CmpUtil::objectToInt64(&obj);
                         root->set_value(key, (void*)&val, specType);
+                        FOUT("Extracting val as INT64 val = " << val << " for key = " << key);
                     }
                     break;
                     case DataType::UINT64:
@@ -778,6 +783,8 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
 {
     root->clear();
 
+    FOUT("Inside extractor erlang");
+    
     // First byte is the version
 
     int index=1;
@@ -819,6 +826,7 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
         if(expr_fields_.find(key) != expr_fields_.end()) {
 
             DataType::Type specType = expr_fields_[key];
+            FOUT("Found field with specType = " << specType);
 
             //------------------------------------------------------------
             // If there is no value for this field, do nothing
@@ -840,6 +848,7 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
                 //------------------------------------------------------------
                 
             } else {
+                FOUT("Trying to erxtract val");
                 
                 try {
                 
@@ -848,24 +857,28 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
                     {
                         uint8_t val = EiUtil::objectToUint8(data, &index);
                         root->set_value(key, (void*)&val, specType);
+                        FOUT("Extracting val as UINT8 " << val << " for key " << key);
                     }
                     break;
                     case DataType::INT64:
                     {
                         int64_t val = EiUtil::objectToInt64(data, &index);
                         root->set_value(key, (void*)&val, specType);
+                        FOUT("Extracting val INT64 " << val << " for key " << key);
                     }
                     break;
                     case DataType::UINT64:
                     {
                         uint64_t val = EiUtil::objectToUint64(data, &index);
                         root->set_value(key, (void*)&val, DataType::UINT64);
+                        FOUT("Extracting val UINT64 " << val << " for key " << key);
                     }
                     break;
                     case DataType::DOUBLE:
                     {
                         double val = EiUtil::objectToDouble(data, &index);
                         root->set_value(key, (void*)&val, specType);
+                        FOUT("Extracting val DOUBLE " << val << " for key " << key);
                     }
                     break;
 

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -549,7 +549,7 @@ void ExtractorMsgpack::extract(const char* data, size_t size, ExpressionNode<boo
     unsigned nField = 0;
     
     StringBuf sBuf;
-    for(int i=0; i < map_size && nField < nField_; i++) {
+    for(unsigned int i=0; i < map_size && nField < nField_; i++) {
 
         //------------------------------------------------------------
         // First read the field key

--- a/c_src/extractor.cc
+++ b/c_src/extractor.cc
@@ -932,8 +932,7 @@ void ExtractorErlang::extract(const char* ptr, size_t size, ExpressionNode<bool>
             //------------------------------------------------------------
 
         } else {
-//          EiUtil::skipLastReadObject(data, &index);
-            EiUtil::skipNext(data, &index);
+            EiUtil::skipLastReadObject(data, &index);
         }
     }
 }

--- a/c_src/extractor.h
+++ b/c_src/extractor.h
@@ -62,6 +62,8 @@ public:
     std::map<std::string, eleveldb::DataType::Type> expr_field_specs_;
     std::map<std::string, eleveldb::DataType::Type> field_types_;
 
+    unsigned nField_;
+    
     bool typesParsed_;
 };
 

--- a/c_src/filter_parser.cc
+++ b/c_src/filter_parser.cc
@@ -49,9 +49,9 @@
             break;                                                    \
         case DataType::UINT64:                                        \
             NEW_BIN(ClassName, uint64_t,       type);                 \
-            break;                                                    \
-        case DataType::INT64:                                          \
-            NEW_BIN(ClassName, int64_t,        type);                  \
+            break;                                                     \
+        case DataType::INT64:                                           \
+            NEW_BIN(ClassName, int64_t,        type);                   \
             break;                                                      \
         case DataType::DOUBLE:                                          \
             NEW_BIN(ClassName, double,         type);                   \
@@ -76,60 +76,60 @@
 //=======================================================================
 
 template<typename T> ExpressionNode<T>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     ThrowRuntimeError("Called an unsupported version of parse_const_expr");
     return NULL;
 }
 
 template<> ExpressionNode<uint8_t>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     int val = eleveldb::ErlUtil::getValAsUint8(env, operand);
     return new ConstantValue<uint8_t>(val);
 }
 
 template<> ExpressionNode<int>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     int val = eleveldb::ErlUtil::getValAsInt32(env, operand);
     return new ConstantValue<int>(val);
 }
 
 template<> ExpressionNode<unsigned int>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     unsigned int val = eleveldb::ErlUtil::getValAsUint32(env, operand);
     return new ConstantValue<unsigned int>(val);
 }
 
 template<> ExpressionNode<int64_t>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     int64_t val = eleveldb::ErlUtil::getValAsInt64(env, operand);
     return new ConstantValue<int64_t>(val);
 }
 
 template<> ExpressionNode<uint64_t>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     uint64_t val = eleveldb::ErlUtil::getValAsUint64(env, operand);
     return new ConstantValue<uint64_t>(val);
 }
 
 template<> ExpressionNode<double>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     double val = eleveldb::ErlUtil::getValAsDouble(env, operand);
     return new ConstantValue<double>(val);
 }
 
 template<> ExpressionNode<std::string>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     return new ConstantValue<std::string>(eleveldb::ErlUtil::getString(env, operand));
 }
 
 template<> ExpressionNode<unsigned char*>* 
-parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
     std::vector<unsigned char> val = eleveldb::ErlUtil::getBinary(env, operand);
     return new ConstantValue<unsigned char*>(val);
 }
 
 template<typename T> ExpressionNode<T>* 
-parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM root, Extractor& ext, bool throwIfInvalid) {
+parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM root, ExtractorMap& ext, bool throwIfInvalid) {
 
     try {
 
@@ -180,7 +180,7 @@ parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM root, Extractor& ext, bool th
 //=======================================================================
 
 template<> ExpressionNode<bool>* 
-parse_expression_node<bool>(ErlNifEnv* env, ERL_NIF_TERM root, Extractor& ext, bool throwIfInvalid) {
+parse_expression_node<bool>(ErlNifEnv* env, ERL_NIF_TERM root, ExtractorMap& ext, bool throwIfInvalid) {
 
     try {
 
@@ -234,7 +234,7 @@ parse_expression_node<bool>(ErlNifEnv* env, ERL_NIF_TERM root, Extractor& ext, b
 //=======================================================================
 
 ExpressionNode<bool>*
-parse_equals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_equals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         DataType::Type type = ext.cTypeOf(env, args[1], args[2], throwIfInvalid);
         SWITCH_TYPE(EqOperator);
@@ -251,7 +251,7 @@ parse_equals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ex
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_nequals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_nequals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         DataType::Type type = ext.cTypeOf(env, args[1], args[2], throwIfInvalid);
         SWITCH_TYPE(NeqOperator);
@@ -268,7 +268,7 @@ parse_nequals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& e
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_lt_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_lt_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         DataType::Type type = ext.cTypeOf(env, args[1], args[2], throwIfInvalid);
         
@@ -296,7 +296,7 @@ parse_lt_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, b
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_lte_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_lte_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         DataType::Type type = ext.cTypeOf(env, args[1], args[2], throwIfInvalid);
 
@@ -324,7 +324,7 @@ parse_lte_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, 
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_gt_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_gt_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         DataType::Type type = ext.cTypeOf(env, args[1], args[2], throwIfInvalid);
         
@@ -352,7 +352,7 @@ parse_gt_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, b
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_gte_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_gte_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         DataType::Type type = ext.cTypeOf(env, args[1], args[2], throwIfInvalid);
         
@@ -380,7 +380,7 @@ parse_gte_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, 
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_and_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_and_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         
         ExpressionNode<bool>* left  = parse_expression_node<bool>(env, args[1], ext, throwIfInvalid);
@@ -423,7 +423,7 @@ parse_and_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, 
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_or_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid) {
+parse_or_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid) {
     if(args.size() == 3) {
         
         ExpressionNode<bool>* left  = parse_expression_node<bool>(env, args[1], ext, throwIfInvalid);
@@ -466,12 +466,17 @@ parse_or_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, b
 //=======================================================================
 
 template<typename T> ExpressionNode<T>* 
-parse_field_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
+parse_field_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext) {
 
     try {
 
         std::string fieldName = eleveldb::ErlUtil::getBinaryAsString(env, operand);
+
+        // Each field must be added to all extractors that might be used to
+        // filter data
+        
         ext.add_field(fieldName);
+
         return new FieldValue<T>(fieldName, ext.cTypeOf(fieldName));
 
     } catch(...) {
@@ -485,6 +490,6 @@ parse_field_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext) {
 //=======================================================================
 
 ExpressionNode<bool>* 
-parse_range_filter_opts(ErlNifEnv* env, ERL_NIF_TERM options, Extractor& ext, bool throwIfInvalid) {
+parse_range_filter_opts(ErlNifEnv* env, ERL_NIF_TERM options, ExtractorMap& ext, bool throwIfInvalid) {
     return parse_expression_node<bool>(env, options, ext, throwIfInvalid);
 }

--- a/c_src/filter_parser.cc
+++ b/c_src/filter_parser.cc
@@ -193,7 +193,7 @@ parse_expression_node<bool>(ErlNifEnv* env, ERL_NIF_TERM root, ExtractorMap& ext
             if(op == eleveldb::filter::EQ_OP || 
                op == eleveldb::filter::EQEQ_OP) {
                 return parse_equals_expr(env, opArgs, ext, throwIfInvalid);
-	    } else if(op == eleveldb::filter::NEQ_OP) {
+            } else if(op == eleveldb::filter::NEQ_OP) {
                 return parse_nequals_expr(env, opArgs, ext, throwIfInvalid);
             } else if(op == eleveldb::filter::LT_OP) {
                 return parse_lt_expr(env, opArgs, ext, throwIfInvalid);

--- a/c_src/filter_parser.h
+++ b/c_src/filter_parser.h
@@ -26,27 +26,27 @@ namespace eleveldb {
     }
 }
 
-ExpressionNode<bool>* parse_range_filter_opts(ErlNifEnv* env, ERL_NIF_TERM options, Extractor& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_range_filter_opts(ErlNifEnv* env, ERL_NIF_TERM options, ExtractorMap& ext, bool throwIfInvalid);
 
 template<typename T>
-ExpressionNode<T>* parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM root, Extractor& ext, bool throwIfInvalid);
+ExpressionNode<T>* parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM root, ExtractorMap& ext, bool throwIfInvalid);
 
 template<typename T>
-ExpressionNode<T>* parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM rooti, Extractor& ext, bool throwIfInvalid);
+ExpressionNode<T>* parse_expression_node(ErlNifEnv* env, ERL_NIF_TERM rooti, ExtractorMap& ext, bool throwIfInvalid);
 
 template<typename T>
-ExpressionNode<T>* parse_field_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext);
+ExpressionNode<T>* parse_field_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext);
 
 template<typename T>
-ExpressionNode<T>* parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, Extractor& ext);
+ExpressionNode<T>* parse_const_expr(ErlNifEnv* env, ERL_NIF_TERM operand, ExtractorMap& ext);
 
 
-ExpressionNode<bool>* parse_equals_expr( ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_nequals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_lt_expr(     ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_lte_expr(    ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_gt_expr(     ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_gte_expr(    ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_and_expr(    ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
-ExpressionNode<bool>* parse_or_expr(     ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, Extractor& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_equals_expr( ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_nequals_expr(ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_lt_expr(     ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_lte_expr(    ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_gt_expr(     ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_gte_expr(    ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_and_expr(    ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
+ExpressionNode<bool>* parse_or_expr(     ErlNifEnv* env, std::vector<ERL_NIF_TERM>& args, ExtractorMap& ext, bool throwIfInvalid);
 #endif

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -972,7 +972,7 @@ work_result RangeScanTask::DoWork()
                 //------------------------------------------------------------
 
                 if(range_filter_) {
-
+                    FOUT("Using range filter");
                     //------------------------------------------------------------
                     // Also check if the key can be parsed.  If TS-encoded
                     // data and non-TS encoded data are interleaved, this
@@ -988,7 +988,8 @@ work_result RangeScanTask::DoWork()
                         // that it exists in the map because
                         // riakObjectContentsCanBeParsed() would have
                         // returned false if it didn't)
-
+                        FOUT("Getting extractor for magic = " << (int)encMagic);
+                        
                         extractor_ = extractorMap_.extractorNoCheck(encMagic);
 
                         // And extract the field values that will be
@@ -1002,6 +1003,8 @@ work_result RangeScanTask::DoWork()
                         
                         filter_passed = range_filter_->evaluate();
 
+                        FOUT("Filter passed = " << filter_passed);
+                        
                     } else {
                         filter_passed = false;
                     }

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -997,7 +997,7 @@ work_result RangeScanTask::DoWork()
                         // And extract the field values that will be
                         // evaluated against the filter
 
-                        STDOUT("Extracting object for " << key.data());
+                        STDOUT("Extracting object for " << ErlUtil::formatAsString((char*)key.data(), key.size()));
                         
                         extractor_->extractRiakObject(value.data(), value.size(), range_filter_);
                         
@@ -1006,6 +1006,9 @@ work_result RangeScanTask::DoWork()
                         //------------------------------------------------------------
                         
                         filter_passed = range_filter_->evaluate();
+
+                        STDOUT("Done extracting object for " << ErlUtil::formatAsString((char*)key.data(), key.size())
+                               << " filter_passed = " << filter_passed);
 
                     } else {
                         ThrowRuntimeError("range_filter set, but couldn't parse riak object");
@@ -1029,6 +1032,8 @@ work_result RangeScanTask::DoWork()
                 os << err.what() << std::endl << "While processing key: " 
                    << ErlUtil::formatAsString((unsigned char*)key.data(), key.size());
 
+                STDOUT("Caught an error: " << os.str());
+                
                 sendMsg(msg_env, ATOM_STREAMING_ERROR, pid, os.str());
 
                 if(binaryAllocated)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -972,7 +972,7 @@ work_result RangeScanTask::DoWork()
                 //------------------------------------------------------------
 
                 if(range_filter_) {
-                    FOUT("Using range filter");
+
                     //------------------------------------------------------------
                     // Also check if the key can be parsed.  If TS-encoded
                     // data and non-TS encoded data are interleaved, this
@@ -988,7 +988,6 @@ work_result RangeScanTask::DoWork()
                         // that it exists in the map because
                         // riakObjectContentsCanBeParsed() would have
                         // returned false if it didn't)
-                        FOUT("Getting extractor for magic = " << (int)encMagic);
                         
                         extractor_ = extractorMap_.extractorNoCheck(encMagic);
 
@@ -1003,8 +1002,6 @@ work_result RangeScanTask::DoWork()
                         
                         filter_passed = range_filter_->evaluate();
 
-                        FOUT("Filter passed = " << filter_passed);
-                        
                     } else {
                         filter_passed = false;
                     }
@@ -1019,7 +1016,7 @@ work_result RangeScanTask::DoWork()
                 std::ostringstream os;
                 os << err.what() << std::endl << "While processing key: " 
                    << ErlUtil::formatBinary((unsigned char*)key.data(), key.size());
-                
+
                 sendMsg(msg_env, ATOM_STREAMING_ERROR, pid, os.str());
 
                 if(binaryAllocated)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -993,7 +993,7 @@ work_result RangeScanTask::DoWork()
 
                         // And extract the field values that will be
                         // evaluated against the filter
-                        
+
                         extractor_->extractRiakObject(value.data(), value.size(), range_filter_);
                         
                         //------------------------------------------------------------

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -997,8 +997,6 @@ work_result RangeScanTask::DoWork()
                         // And extract the field values that will be
                         // evaluated against the filter
 
-                        STDOUT("Extracting object for " << ErlUtil::formatAsString((char*)key.data(), key.size()));
-                        
                         extractor_->extractRiakObject(value.data(), value.size(), range_filter_);
                         
                         //------------------------------------------------------------
@@ -1006,9 +1004,6 @@ work_result RangeScanTask::DoWork()
                         //------------------------------------------------------------
                         
                         filter_passed = range_filter_->evaluate();
-
-                        STDOUT("Done extracting object for " << ErlUtil::formatAsString((char*)key.data(), key.size())
-                               << " filter_passed = " << filter_passed);
 
                     } else {
                         ThrowRuntimeError("range_filter set, but couldn't parse riak object");
@@ -1032,8 +1027,6 @@ work_result RangeScanTask::DoWork()
                 os << err.what() << std::endl << "While processing key: " 
                    << ErlUtil::formatAsString((unsigned char*)key.data(), key.size());
 
-                STDOUT("Caught an error: " << os.str());
-                
                 sendMsg(msg_env, ATOM_STREAMING_ERROR, pid, os.str());
 
                 if(binaryAllocated)

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -826,7 +826,7 @@ void RangeScanTask::sendMsg(ErlNifEnv * msg_env, ERL_NIF_TERM atom, ErlNifPid pi
 {
     if(!sync_obj_->IsConsumerDead()) {
         ERL_NIF_TERM ref_copy = enif_make_copy(msg_env, caller_ref_term);
-	ERL_NIF_TERM msg_str  = enif_make_string(msg_env, msg.c_str(), ERL_NIF_LATIN1);
+        ERL_NIF_TERM msg_str  = enif_make_string(msg_env, msg.c_str(), ERL_NIF_LATIN1);
         ERL_NIF_TERM msg      = enif_make_tuple3(msg_env, atom, ref_copy, msg_str);
         
         enif_send(NULL, &pid, msg_env, msg);
@@ -928,7 +928,7 @@ work_result RangeScanTask::DoWork()
             // If data are present in the batch (ie, out_offset != 0),
             // send the batch now
 
-	    if (out_offset) {
+            if (out_offset) {
             
                 // Shrink it to final size.
 
@@ -942,21 +942,21 @@ work_result RangeScanTask::DoWork()
             break;
         }
 
-	//------------------------------------------------------------
-	// Else keep going; shove the next entry in the batch, but
-	// only if it passes any user-specified filter.  We default to
-	// filter_passed = true, in case we are not using a filter,
-	// which will cause all keys to be returned
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // Else keep going; shove the next entry in the batch, but
+        // only if it passes any user-specified filter.  We default to
+        // filter_passed = true, in case we are not using a filter,
+        // which will cause all keys to be returned
+        //------------------------------------------------------------
 
         leveldb::Slice key   = iter->key();
         leveldb::Slice value = iter->value();
 
         bool filter_passed = true;
 
-	//------------------------------------------------------------
-	// If we are using a filter, evaluate it here
-	//------------------------------------------------------------
+        //------------------------------------------------------------
+        // If we are using a filter, evaluate it here
+        //------------------------------------------------------------
 
         if(options_.useRangeFilter_) {
 
@@ -1030,9 +1030,9 @@ work_result RangeScanTask::DoWork()
         }
 
         if (filter_passed) {
-	  
+          
             const size_t ksz = key.size();
-	    const size_t vsz = value.size();
+            const size_t vsz = value.size();
 
             const size_t ksz_sz = VarintLength(ksz);
             const size_t vsz_sz = VarintLength(vsz);
@@ -1041,17 +1041,17 @@ work_result RangeScanTask::DoWork()
             const size_t next_offset = out_offset + esz;
 
             // Allocate the output data array if this is the first data
-	    // (i.e., if out_offset == 0)
+            // (i.e., if out_offset == 0)
 
             if(out_offset == 0) {
                 enif_alloc_binary(initial_bin_size, &bin);
                 binaryAllocated = true;
             }
 
-	    //------------------------------------------------------------
+            //------------------------------------------------------------
             // If we need more space, allocate it exactly since that means we
             // reached the batch max anyway and will send it right away
-	    //------------------------------------------------------------
+            //------------------------------------------------------------
 
             if(next_offset > bin.size)
                 enif_realloc_binary(&bin, next_offset);
@@ -1065,11 +1065,11 @@ work_result RangeScanTask::DoWork()
             memcpy(out + ksz_sz + ksz + vsz_sz, value.data(), vsz);
 
             out_offset = next_offset;
-	    
-	    //------------------------------------------------------------
-	    // If we've reached the maximum number of bytes to include in
-	    // the batch, possibly shrink the binary and send it
-	    //------------------------------------------------------------
+            
+            //------------------------------------------------------------
+            // If we've reached the maximum number of bytes to include in
+            // the batch, possibly shrink the binary and send it
+            //------------------------------------------------------------
 
             if(out_offset >= options_.max_batch_bytes) {
 
@@ -1083,18 +1083,18 @@ work_result RangeScanTask::DoWork()
                 sync_obj_->AddBytes(out_offset);
 
                 out_offset = 0;
-	    }
+            }
 
-	    //------------------------------------------------------------
-	    // Increment the number of keys read and step to the next
-	    // key
-	    //------------------------------------------------------------
+            //------------------------------------------------------------
+            // Increment the number of keys read and step to the next
+            // key
+            //------------------------------------------------------------
 
-	    ++num_read;
+            ++num_read;
 
-	} else {
-            //	  COUT("Filter DIDN'T pass");
-	}
+        } else {
+            //    COUT("Filter DIDN'T pass");
+        }
 
         iter->Next();
     }

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -997,6 +997,8 @@ work_result RangeScanTask::DoWork()
                         // And extract the field values that will be
                         // evaluated against the filter
 
+                        STDOUT("Extracting object for " << key.data());
+                        
                         extractor_->extractRiakObject(value.data(), value.size(), range_filter_);
                         
                         //------------------------------------------------------------

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -373,7 +373,6 @@ struct RangeScanOptions {
 
     // Filter options
 
-    Encoding::Type encodingType_;
     ERL_NIF_TERM rangeFilterSpec_;
     ErlNifEnv* env_;
     bool useRangeFilter_;
@@ -480,6 +479,15 @@ protected:
     bool has_end_key_;
     SyncObject* sync_obj_;
     ExpressionNode<bool>* range_filter_;
+
+    // RangeScanTask::extractorMap_ contains a map of allocated
+    // extractors for valid encodings.  
+    
+    ExtractorMap extractorMap_;
+
+    // RangeScanTask::extractor_ is just a temporary pointer that will
+    // point to the right extractor for the current data record
+    
     Extractor* extractor_;
 
 private:

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -45,6 +45,7 @@
          encode/2,
          decodeei/1,
          decodeterm/1,
+         skipterm/2,
          current_usec/0]).
 
 %% for testing
@@ -184,7 +185,10 @@ encode(Val, _) ->
     term_to_binary(Val).
 
 decodeterm(Term) ->
-    decodeei(term_to_binary(Term)).
+    decodeei({term_to_binary(Term), decode}).
+
+skipterm(Term, N) ->
+    decodeei({term_to_binary(Term), skip, N}).
 
 decodeei(_Bin) ->
     erlang:nif_error({error, not_loaded}).

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -43,6 +43,8 @@
          parse_string/1,
          is_empty/1,
          encode/2,
+         decodeei/1,
+         decodeterm/1,
          current_usec/0]).
 
 %% for testing
@@ -180,6 +182,12 @@ encode(Val, binary) when is_binary(Val)->
     Val;
 encode(Val, _) ->
     term_to_binary(Val).
+
+decodeterm(Term) ->
+    decodeei(term_to_binary(Term)).
+
+decodeei(_Bin) ->
+    erlang:nif_error({error, not_loaded}).
 
 -spec async_open(reference(), string(), open_options()) -> ok.
 async_open(_CallerRef, _Name, _Opts) ->

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -43,7 +43,8 @@
          parse_string/1,
          is_empty/1,
          encode/2,
-         current_usec/0]).
+         current_usec/0,
+	 stdout/2]).
 
 %% for testing
 -export([
@@ -180,6 +181,13 @@ encode(Val, binary) when is_binary(Val)->
     Val;
 encode(Val, _) ->
     term_to_binary(Val).
+
+stdout(Format, Data) ->
+    Bytes = io:format(Format, Data),
+    print_to_stdout(Bytes).
+
+print_to_stdout(_Bytes) ->
+    erlang:nif_error({error, not_loaded}).
 
 -spec async_open(reference(), string(), open_options()) -> ok.
 async_open(_CallerRef, _Name, _Opts) ->

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -157,10 +157,7 @@ init() ->
 
 -type fold_method() :: iterator | streaming.
 
--type encoding() :: erlang | msgpack.
-
 -type fold_options() :: [read_option() |
-                         {encoding, encoding()} |
                          {fold_method, fold_method()} |
                          {start_key, binary()} |
                          {end_key, binary() | undefined} |

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -43,8 +43,7 @@
          parse_string/1,
          is_empty/1,
          encode/2,
-         current_usec/0,
-	 stdout/2]).
+         current_usec/0]).
 
 %% for testing
 -export([
@@ -181,13 +180,6 @@ encode(Val, binary) when is_binary(Val)->
     Val;
 encode(Val, _) ->
     term_to_binary(Val).
-
-stdout(Format, Data) ->
-    Bytes = io:format(Format, Data),
-    print_to_stdout(Bytes).
-
-print_to_stdout(_Bytes) ->
-    erlang:nif_error({error, not_loaded}).
 
 -spec async_open(reference(), string(), open_options()) -> ok.
 async_open(_CallerRef, _Name, _Opts) ->

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -338,7 +338,7 @@ myformat(T,Val1, Val2) ->
 %%=======================================================================
 
 %%------------------------------------------------------------
-%% Recursive function to putkeys in the database
+%% Recursive function to put keys in the database
 %%------------------------------------------------------------
 
 putKeysObj(N) -> 
@@ -504,10 +504,16 @@ packObj_test() ->
 %%-----------------------------------------------------------------------
 
 putKeyNormalOps(Ref) ->
-    addKey(Ref, 1, [{<<"f1">>, 1}, {<<"f2">>, <<"test1">>}, {<<"f3">>, 1.0}, {<<"f4">>, false}, {<<"f5">>, [1,2,3]}, {<<"f6">>, 1000}]),
-    addKey(Ref, 2, [{<<"f1">>, 2}, {<<"f2">>, <<"test2">>}, {<<"f3">>, 2.0}, {<<"f4">>, true},  {<<"f5">>, [2,3,4]}, {<<"f6">>, 2000}]),
-    addKey(Ref, 3, [{<<"f1">>, 3}, {<<"f2">>, <<"test3">>}, {<<"f3">>, 3.0}, {<<"f4">>, false}, {<<"f5">>, [3,4,5]}, {<<"f6">>, 3000}]),
-    addKey(Ref, 4, [{<<"f1">>, 4}, {<<"f2">>, <<"test4">>}, {<<"f3">>, 4.0}, {<<"f4">>, true},  {<<"f5">>, [4,5,6]}, {<<"f6">>, 4000}]).
+    putKeyNormalOps(Ref, msgpack).
+
+putKeyNormalOpsErlang(Ref) ->
+    putKeyNormalOps(Ref, erlang).
+
+putKeyNormalOps(Ref, Enc) ->
+    addKey(Ref, 1, [{<<"f1">>, 1}, {<<"f2">>, <<"test1">>}, {<<"f3">>, 1.0}, {<<"f4">>, false}, {<<"f5">>, [1,2,3]}, {<<"f6">>, 1000}], Enc),
+    addKey(Ref, 2, [{<<"f1">>, 2}, {<<"f2">>, <<"test2">>}, {<<"f3">>, 2.0}, {<<"f4">>, true},  {<<"f5">>, [2,3,4]}, {<<"f6">>, 2000}], Enc),
+    addKey(Ref, 3, [{<<"f1">>, 3}, {<<"f2">>, <<"test3">>}, {<<"f3">>, 3.0}, {<<"f4">>, false}, {<<"f5">>, [3,4,5]}, {<<"f6">>, 3000}], Enc),
+    addKey(Ref, 4, [{<<"f1">>, 4}, {<<"f2">>, <<"test4">>}, {<<"f3">>, 4.0}, {<<"f4">>, true},  {<<"f5">>, [4,5,6]}, {<<"f6">>, 4000}], Enc).
 
 defaultEvalFn({N,Nmatch}) ->
     (N > 0) and (N == Nmatch).
@@ -577,6 +583,16 @@ timestampOps_test() ->
     F = <<"f6">>,
     Val = 2000,
     PutFn = fun putKeyNormalOps/1,
+    EvalFn = fun defaultEvalFn/1,
+    Res = allOps({F, {Val}, timestamp, PutFn, EvalFn}),
+    ?assert(Res),
+    Res.
+
+timestampOpsErlang_test() ->
+    io:format("timestampOps_test~n"),
+    F = <<"f6">>,
+    Val = 2000,
+    PutFn = fun putKeyNormalOpsErlang/1,
     EvalFn = fun defaultEvalFn/1,
     Res = allOps({F, {Val}, timestamp, PutFn, EvalFn}),
     ?assert(Res),

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -533,7 +533,6 @@ putKeyNormalOps(Ref, mixed) ->
     Rows = getKeyNormalOps(),
     lists:foreach(fun (Row) ->
                           I = element(2, hd(Row)),
-			  io:format("Adding key ~p~n", [Row]),
 			  Enc = 
 			      case I rem 2 of
 				  0 ->
@@ -547,7 +546,6 @@ putKeyNormalOps(Ref, Enc) ->
     Rows = getKeyNormalOps(),
     lists:foreach(fun (Row) ->
                           I = element(2, hd(Row)),
-			  io:format("Adding key ~p~n", [Row]),
                           addKey(Ref, I, Row, Enc)
                   end, Rows).
 

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -438,6 +438,7 @@ streamFoldTest(Filter, PutKeyFun, []) ->
                  [getKeyVal(K,V) | Acc]
          end,
 
+    eleveldb:stdout("Folding with Ops = ~p~n", [Opts]),
     Keys = 
         try 
             Acc = eleveldb:fold(Ref, FF, [], Opts),
@@ -456,7 +457,7 @@ streamFoldTest(Filter, PutKeyFun, []) ->
                 ok = eleveldb:close(Ref),
                 []
         end,
-
+    eleveldb:stdout("Done folding with Ops = ~p~n Key size = ~p~n", [Opts, length(Keys)]),
     Keys.
 
 get_field(Field, List) ->

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -438,7 +438,6 @@ streamFoldTest(Filter, PutKeyFun, []) ->
                  [getKeyVal(K,V) | Acc]
          end,
 
-    eleveldb:stdout("Folding with Ops = ~p~n", [Opts]),
     Keys = 
         try 
             Acc = eleveldb:fold(Ref, FF, [], Opts),
@@ -457,7 +456,6 @@ streamFoldTest(Filter, PutKeyFun, []) ->
                 ok = eleveldb:close(Ref),
                 []
         end,
-    eleveldb:stdout("Done folding with Ops = ~p~n Key size = ~p~n", [Opts, length(Keys)]),
     Keys.
 
 get_field(Field, List) ->
@@ -834,6 +832,9 @@ anyCompOps(Args) ->
 %%------------------------------------------------------------
 
 timestampOps_test() ->
+    {timeout, 60, fun() -> timestampOpsTests() end}.
+			  
+timestampOpsTests() ->
     timestampOps(erlang) and timestampOps(msgpack) and timestampOps(mixed).
 
 timestampOps(Enc) ->
@@ -853,17 +854,11 @@ timestampOps(Enc) ->
 %% Test sint64 operations, because now that's what we're calling integers
 %%------------------------------------------------------------
 
+sint64Ops_test() ->
+    {timeout, 60, fun() -> sint64OpsTests() end}.
+
 sint64OpsTests() ->
-    sint64OpsMsgpack_test() and sint64OpsErlang_test() and sint64OpsMixed_test().
-
-sint64OpsMsgpack_test() ->
-    sint64Ops(msgpack).
-
-sint64OpsErlang_test() ->
-    sint64Ops(erlang).
-
-sint64OpsMixed_test() ->
-    sint64Ops(mixed).
+    sint64Ops(msgpack) and sint64Ops(erlang) and sint64Ops(mixed).
 
 sint64Ops(Enc) ->
     io:format("sint64Ops_test with ~p encoding~n", [Enc]),
@@ -885,6 +880,9 @@ sint64Ops(Enc) ->
 %%------------------------------------------------------------
 
 varIntOps_test() ->
+    {timeout, 60, fun() -> varIntOpsTests() end}.
+
+varIntOpsTests() ->
     varIntOps(msgpack) and varIntOps(erlang) and varIntOps(erlang).
 
 varIntOps(Enc) ->
@@ -906,6 +904,9 @@ varIntOps(Enc) ->
 %%------------------------------------------------------------
 
 varcharOps_test() ->
+   {timeout, 60, fun() -> varcharOpsTests() end}.
+			 
+varcharOpsTests() ->
     varcharOps(msgpack) and varcharOps(erlang) and varcharOps(mixed).
 
 varcharOps(Enc) ->
@@ -927,6 +928,9 @@ varcharOps(Enc) ->
 %%------------------------------------------------------------
 
 doubleOps_test() ->
+    {timeout, 60, fun() -> doubleOpsTests() end}.
+
+doubleOpsTests() ->
     doubleOps(msgpack) and doubleOps(erlang) and doubleOps(mixed).
 
 doubleOps(Enc) ->
@@ -947,6 +951,9 @@ doubleOps(Enc) ->
 %%------------------------------------------------------------
 
 boolOps_test() ->
+    {timeout, 60, fun() -> boolOpsTests() end}.
+			  
+boolOpsTests() ->
     boolOps(msgpack) and boolOps(erlang) and boolOps(mixed).
 
 boolOps(Enc) ->
@@ -967,6 +974,9 @@ boolOps(Enc) ->
 %%------------------------------------------------------------
 
 realisticOps_test() ->
+    {timeout, 60, fun() -> realisticOpsTests() end}.
+
+realisticOpsTests() ->
     realisticOps(erlang) and realisticOps(msgpack) and realisticOps(mixed).
 
 realisticOps(Enc) ->

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -1386,14 +1386,3 @@ readKeysFromTable(Table) ->
 
 r() ->
     readKeysFromTable("1096126227998177188652763624537212264741949407232").
-
-testComp() ->
-    profiler:profile({start, m1}),
-    sut:realisticOps(msgpack),
-    profiler:profile({stop, m1}),
-
-    profiler:profile({start, e1}),
-    sut:realisticOps(erlang),
-    profiler:profile({stop, e1}),
-
-    profiler:profile({debug}).

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -845,8 +845,7 @@ timestampOps(Enc) ->
 
     %% Timestamps support all ops
 
-%%    Res = allOps({F, {Val}, timestamp, PutFn, EvalFn, []}),
-    Res = eqOps({F, {Val}, timestamp, PutFn, EvalFn, []}),
+    Res = allOps({F, {Val}, timestamp, PutFn, EvalFn, []}),
     ?assert(Res),
     Res.
 
@@ -854,8 +853,17 @@ timestampOps(Enc) ->
 %% Test sint64 operations, because now that's what we're calling integers
 %%------------------------------------------------------------
 
-sint64Ops_test() ->
-    sint64Ops(msgpack) and sint64Ops(erlang) and sint64Ops(mixed).
+sint64OpsTests() ->
+    sint64OpsMsgpack_test() and sint64OpsErlang_test() and sint64OpsMixed_test().
+
+sint64OpsMsgpack_test() ->
+    sint64Ops(msgpack).
+
+sint64OpsErlang_test() ->
+    sint64Ops(erlang).
+
+sint64OpsMixed_test() ->
+    sint64Ops(mixed).
 
 sint64Ops(Enc) ->
     io:format("sint64Ops_test with ~p encoding~n", [Enc]),
@@ -997,7 +1005,7 @@ anyOps_test() ->
 %%------------------------------------------------------------
 
 normalOpsTests() ->
-    sint64Ops_test() and varcharOps_test() and boolOps_test() and doubleOps_test() and anyOps_test() and timestampOps_test().
+    sint64OpsTests() and varcharOps_test() and boolOps_test() and doubleOps_test() and anyOps_test() and timestampOps_test().
 
 %%=======================================================================
 %% Test AND + OR comparators

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -450,35 +450,6 @@ streamFoldTest(Filter, PutKeyFun, []) ->
 		[]
 	end,
     io:format("Key list is size = ~p~n", [length(Keys)]),
-    Keys;
-streamFoldTest(Filter, PutKeyFun, [EncAtom]) ->
-    clearDb(),
-    Opts=[{fold_method, streaming},
-	  {range_filter, Filter}],
-    Ref = open(),
-
-    PutKeyFun(Ref),
-
-% Build a list of returned keys
-
-    FF = fun({K,V}, Acc) -> 
-		 [getKeyVal(K,V) | Acc]
-	 end,
-
-    Keys = 
-	try 
-	    profiler:profile({start, EncAtom}),
-	    Acc = eleveldb:fold(Ref, FF, [], Opts),
-	    profiler:profile({stop, EncAtom}),
-	    ok = eleveldb:close(Ref),
-	    lists:reverse(Acc)
-	catch
-	    error:_Error ->
-%%		io:format(user, "Caught an error: closing db~n", []),
-		ok = eleveldb:close(Ref),
-		[]
-	end,
-    io:format("Key list is size = ~p~n", [length(Keys)]),
     Keys.
 
 get_field(Field, List) ->
@@ -603,158 +574,29 @@ getPutFn(erlang) ->
 % Put realistic data
 %------------------------------------------------------------
 
-
 putKeyRealisticOpsMsgpack(Ref) ->
-    putKeyRealisticOps(Ref, msgpack).
+    putSequentialRealisticData({Ref, msgpack, 1467554400000, 1467563400000, 0.5}, 20, 0).
 
 putKeyRealisticOpsErlang(Ref) ->
-    putKeyRealisticOps(Ref, erlang).
+    putSequentialRealisticData({Ref, erlang,  1467554400000, 1467563400000, 0.5}, 20, 0).
 
-putKeyRealisticOps(Ref, Enc) ->
-    Val1 = [{<<"sport_event_uuid">>,
-	     <<"596044d8-86f5-462f-8d94-65b25e7d3fe9">>},
-	    {<<"time">>,1467554464800},
-	    {<<"club_uuid">>,
-	     <<"tNwgAVF1CS4tzWmxLL5LJDYdGGAuS2AVwo0G">>},
-	    {<<"person_uuid">>,
-	     <<"qK1lJFn8QVsUDU1AoP2rYJnm6fr8EoCf6JSH">>},
-	    {<<"sport_uuid">>,
-	     <<"T9YB5aqbBWpLj5FOvcoedvBy3D5TTALuj8Q4">>},
-	    {<<"discipline_uuid">>,
-	     <<"V8tNVS1TVzLa51yo4mNeNUDcN1kq2FCxZe9t">>},
-	    {<<"driver_number">>,
-	     <<"PCPeOKzUocYL3qUy0DtE0ZjnNGbRlK4BXdxX">>},
-	    {<<"person_full_name">>,
-	     <<"8Opspn2qe8um1lhbHVJZOo317maFXocSnuA7">>},
-	    {<<"club_full_name">>,
-	     <<"rmkfVzaZg19Dx1HmbbqSX7chRFaCIPoFqbWM">>},
-	    {<<"abandoned">>,false},
-	    {<<"best_gap_in_time">>,20.0},
-	    {<<"best_gap_in_lap">>,36},
-	    {<<"best_lap">>,79.0},
-	    {<<"best_position">>,65},
-	    {<<"best_sector_1">>,59.0},
-	    {<<"best_sector_2">>,30.0},
-	    {<<"best_sector_3">>,5.0},
-	    {<<"best_speed">>,9.0},
-	    {<<"gap_in_time">>,58.0},
-	    {<<"gap_in_lap">>,56},
-	    {<<"lap_time">>,98.0},
-	    {<<"laps">>,10},
-	    {<<"position">>,59},
-	    {<<"qualification_position">>,77},
-	    {<<"sector_1">>,93.0},
-	    {<<"sector_2">>,3.0},
-	    {<<"sector_3">>,90.0},
-	    {<<"info">>,
-	     <<"9Sfd5IstDpsEhlvCiNt7l67EFKfFQsYGm6Yx">>}],
-
-    Val2 = [{<<"sport_event_uuid">>,
-	     <<"596044d8-86f5-462f-8d94-65b25e7d3fe9">>},
-	    {<<"time">>,1467554466600},
-	    {<<"club_uuid">>,
-	     <<"Zuu7nIHJ840uQxHP1ZTtTq0nA0e5GL8tiMje">>},
-	    {<<"person_uuid">>,
-	     <<"dNtk5xfshSZG8Edl0rYvQ58aJbdrtofoz12l">>},
-	    {<<"sport_uuid">>,
-	     <<"VuorLbl3CkjmRLooJavwXcFk1m6Wm512FPmd">>},
-	    {<<"discipline_uuid">>,
-	     <<"ruf0if1jlCUy4iMOyD3c5DctLrOdCQ0BxCH2">>},
-	    {<<"driver_number">>,
-	     <<"SEmursLHE1yfSq0ssfUQniVqObNiY105yzpD">>},
-	    {<<"person_full_name">>,
-	     <<"E6Ll1B5kI0RSSf9QRiWHEsJ8yiJzxd5tc1uF">>},
-	    {<<"club_full_name">>,
-	     <<"9wOLpIIKtbsg1GSVPMxekDQyXyCPeFoLuJR1">>},
-	    {<<"abandoned">>,false},
-	    {<<"best_gap_in_time">>,97.0},
-	    {<<"best_gap_in_lap">>,2},
-	    {<<"best_lap">>,49.0},
-	    {<<"best_position">>,32},
-	    {<<"best_sector_1">>,19.0},
-	    {<<"best_sector_2">>,67.0},
-	    {<<"best_sector_3">>,25.0},
-	    {<<"best_speed">>,83.0},
-	    {<<"gap_in_time">>,10.0},
-	    {<<"gap_in_lap">>,62},
-	    {<<"lap_time">>,71.0},
-	    {<<"laps">>,-1},
-	    {<<"position">>,2},
-	    {<<"qualification_position">>,34},
-	    {<<"sector_1">>,67.0},
-	    {<<"sector_2">>,44.0},
-	    {<<"sector_3">>,48.0},
-	    {<<"info">>,
-	     <<"3TRYQUE82rPIIPB1RWOe4B4JOpdjoJ3bPZCR">>}],
-    
-    Val3 = [{<<"sport_event_uuid">>,
-	     <<"596044d8-86f5-462f-8d94-65b25e7d3fe9">>},
-	    {<<"time">>,1467554468400},
-	    {<<"club_uuid">>,
-	     <<"XvMFBUzx24djxkEZnqGz0wlpYqQsWcOPHwPi">>},
-	    {<<"person_uuid">>,
-	     <<"PEUvlXlhrtsgsQaouWsBfTxDdf3DUGnwrrWz">>},
-	    {<<"sport_uuid">>,
-	     <<"CR1fvGlVMnjOLK1VSWlJn5uLrQqQaS94TQ8l">>},
-	    {<<"discipline_uuid">>,
-	     <<"7fjDrTMEkrr5LYZNw4sCLYWiyWUJXZEohyfc">>},
-	    {<<"driver_number">>,
-	     <<"casUj7A5Uwmk4VozCt06oMro28VY7zHiissc">>},
-	    {<<"person_full_name">>,
-	     <<"zsreozHdXuh5pQp1U6COE8yGPMQTJ7g9tPrY">>},
-	    {<<"club_full_name">>,
-	     <<"dVPy53WnTofMS7ebTk7TJwixLytijdEKTrA4">>},
-	    {<<"abandoned">>,false},
-	    {<<"best_gap_in_time">>,34.0},
-	    {<<"best_gap_in_lap">>,65},
-	    {<<"best_lap">>,58.0},
-	    {<<"best_position">>,18},
-	    {<<"best_sector_1">>,17.0},
-	    {<<"best_sector_2">>,50.0},
-	    {<<"best_sector_3">>,6.0},
-	    {<<"best_speed">>,26.0},
-	    {<<"gap_in_time">>,83.0},
-	    {<<"gap_in_lap">>,37},
-	    {<<"lap_time">>,24.0},
-	    {<<"laps">>,-1},
-	    {<<"position">>,4},
-	    {<<"qualification_position">>,12},
-	    {<<"sector_1">>,3.0},
-	    {<<"sector_2">>,35.0},
-	    {<<"sector_3">>,12.0},
-	    {<<"info">>,
-	     <<"NdJbBLK3Q2ew8thQ1eQaQpD9iXeaokWSxPoT">>}],
-	
-    addKey(Ref, 1, Val1, Enc),
-    addKey(Ref, 2, Val2, Enc),
-    addKey(Ref, 3, Val3, Enc).
-
-putIntellicoreTestDataMsgpack(Ref) ->
-    putSequentialIntellicoreData({Ref, msgpack, 1467554400000, 1467563400000, 1404.0/137000}, 100000, 0).
-
-putIntellicoreTestDataErlang(Ref) ->
-    putSequentialIntellicoreData({Ref, erlang, 1467554400000, 1467563400000, 1404.0/137000}, 100000, 0).
-
-putIntellicoreTestData(Ref, N, Enc) ->
-    putSequentialIntellicoreData({Ref, Enc, 1467554400000, 1467563400000, 1404.0/137000}, N, 0).
-
-putSequentialIntellicoreData(_Args, _Nrow, _Nrow) ->
+putSequentialRealisticData(_Args, _Nrow, _Nrow) ->
     ok;
-putSequentialIntellicoreData(Args, Nrow, AccRow) ->
+putSequentialRealisticData(Args, Nrow, AccRow) ->
     {Ref, Enc, StartTime, Delta, LapsFrac} = Args,
-    Data = getIntellicoreData(<<"596044d8-86f5-462f-8d94-65b25e7d3fe9">>, StartTime + AccRow * Delta, LapsFrac),
+    Data = getRealisticData(<<"596044d8-86f5-462f-8d94-65b25e7d3fe9">>, StartTime + AccRow * Delta, LapsFrac),
 
-    case AccRow rem 1000 of 
-	0 ->
-	    io:format("Putting row ~p Data = ~p~n", [AccRow, Data]);
-	_ ->
-	    ok
-    end,
+%%    case AccRow rem 10 of 
+%%	0 ->
+%%	    io:format("Putting row ~p Data = ~p~n", [AccRow, Data]);
+%%	_ ->
+%%	    ok
+%%    end,
 
     addKey(Ref, AccRow, Data, Enc),
-    putSequentialIntellicoreData(Args, Nrow, AccRow+1).
+    putSequentialRealisticData(Args, Nrow, AccRow+1).
 
-getIntellicoreData(SportEventUuid, Timestamp, LapsFrac) ->
+getRealisticData(SportEventUuid, Timestamp, LapsFrac) ->
     VarcharSize = length(binary_to_list(SportEventUuid)),
 
     LapsRand = random:uniform(1000),
@@ -1039,24 +881,6 @@ realisticOps(Enc) ->
     Res = gteOps({F, {Val}, sint64, PutFn, EvalFn, []}),
     ?assert(Res),
     Res.
-
-intellicoreLapsTest(Enc) ->
-    io:format("intellicoreLapsTest with ~p encoding~n", [Enc]),
-    F = <<"laps">>,
-    Val = 0,
-    PutFn = 
-	case Enc of 
-	    msgpack ->
-		fun putIntellicoreTestDataMsgpack/1;
-	    _ ->
-		fun putIntellicoreTestDataErlang/1
-	end,
-    EvalFn = fun defaultEvalFn/1,
-    Res = gtOps({F, {Val}, sint64, PutFn, EvalFn, [Enc]}),
-    ?assert(Res),
-    profiler:profile({debug}),
-    Res.
-
 
 %%------------------------------------------------------------
 %% Test any operations

--- a/test/sut.erl
+++ b/test/sut.erl
@@ -366,12 +366,12 @@ addKey(Ref, ValList, Acc, N, mixed) ->
     Key  = list_to_binary("key" ++ string:right(integer_to_list(Acc), Ndig, $0)),
     Obj  = new(<<"bucket">>, Key, ValList),
     Enc = 
-	case Acc rem 2 of
-	    0 ->
-		msgpack;
-	    _ ->
-		erlang
-	end,
+        case Acc rem 2 of
+            0 ->
+                msgpack;
+            _ ->
+                erlang
+        end,
     Val  = to_binary(v1, Obj, Enc),
     ok   = eleveldb:put(Ref, Key, Val, []),
     putKeysObj(Ref, N, Acc+1, mixed);
@@ -427,7 +427,7 @@ getKeyVal(B,K,V) ->
 streamFoldTest(Filter, PutKeyFun, []) ->
     clearDb(),
     Opts=[{fold_method, streaming},
-	  {range_filter, Filter}],
+          {range_filter, Filter}],
     Ref = open(),
 
     PutKeyFun(Ref),
@@ -435,20 +435,20 @@ streamFoldTest(Filter, PutKeyFun, []) ->
 % Build a list of returned keys
 
     FF = fun({K,V}, Acc) -> 
-		 [getKeyVal(K,V) | Acc]
-	 end,
+                 [getKeyVal(K,V) | Acc]
+         end,
 
     Keys = 
-	try 
-	    Acc = eleveldb:fold(Ref, FF, [], Opts),
-	    ok = eleveldb:close(Ref),
-	    lists:reverse(Acc)
-	catch
-	    error:_Error ->
-%%		io:format(user, "Caught an error: closing db~n", []),
-		ok = eleveldb:close(Ref),
-		[]
-	end,
+        try 
+            Acc = eleveldb:fold(Ref, FF, [], Opts),
+            ok = eleveldb:close(Ref),
+            lists:reverse(Acc)
+        catch
+            error:_Error ->
+%%              io:format(user, "Caught an error: closing db~n", []),
+                ok = eleveldb:close(Ref),
+                []
+        end,
     io:format("Key list is size = ~p~n", [length(Keys)]),
     Keys.
 
@@ -470,14 +470,14 @@ match(V1,{_FilterVal, CompVal},CompFun) ->
     match(V1, CompVal, CompFun);
 match(V1,V2,CompFun) ->
     case CompFun(V1,V2) of
-	true -> 1;
-	_ -> 0
+        true -> 1;
+        _ -> 0
     end.
 
 fieldsMatching(Vals, Field, CompVal, CompFun) ->
 %%    io:format("Got Vals = ~p~n", [lists:flatten(Vals)]),
     lists:foldl(fun(Val, {N, Nmatch}) -> 
-			{N + 1, Nmatch + match(Val, Field, CompVal, CompFun)} end, {0,0}, Vals).
+                        {N + 1, Nmatch + match(Val, Field, CompVal, CompFun)} end, {0,0}, Vals).
 
 %%=======================================================================
 %% Actual tests begin here
@@ -515,9 +515,9 @@ putKeyNormalOpsErlang(Ref) ->
 putKeyNormalOps(Ref, Enc) ->
     Rows = getKeyNormalOps(),
     lists:foreach(fun (Row) ->
-			  I = element(2, hd(Row)),
-			  addKey(Ref, I, Row, Enc)
-		  end, Rows).
+                          I = element(2, hd(Row)),
+                          addKey(Ref, I, Row, Enc)
+                  end, Rows).
 
 %------------------------------------------------------------
 % Return a list of keys used for testing
@@ -526,33 +526,33 @@ putKeyNormalOps(Ref, Enc) ->
 getKeyNormalOps() ->
     FieldCount = 10,
     VarIntFn = 
-	fun(I) ->
-		Prefactor = 
-		    case I rem 2 of
-			0 -> 
-			    1;
-			_ ->
-			    -1
-		    end,
-		AddFactor = 
-		    case (I-1) div 2 of
-			0 ->
-			    0;
-			1 ->
-			    256;
-			2 ->
-			    65536;
-			3 ->
-			    4294967296;
-			_ ->
-			    1099511627776
-		    end,
-		Prefactor * (I + AddFactor)
-	end,
+        fun(I) ->
+                Prefactor = 
+                    case I rem 2 of
+                        0 -> 
+                            1;
+                        _ ->
+                            -1
+                    end,
+                AddFactor = 
+                    case (I-1) div 2 of
+                        0 ->
+                            0;
+                        1 ->
+                            256;
+                        2 ->
+                            65536;
+                        3 ->
+                            4294967296;
+                        _ ->
+                            1099511627776
+                    end,
+                Prefactor * (I + AddFactor)
+        end,
 
     Rows = [ [{<<"f1">>, I },
               {<<"f2">>, list_to_binary("test" ++ integer_to_list(I))}, %%<< varchar
-	      {<<"f3">>, I * 1.0},                  %%<< double
+              {<<"f3">>, I * 1.0},                  %%<< double
               {<<"f4">>, I rem 2 =:= 0},            %%<< boolean                                                                                                                           
               {<<"f5">>, lists:seq(I, I + 2)},      %%<< list (not a TS type)                                                                                                              
               {<<"f6">>, I * 1000},                 %%<< sint64                                                                                                                            
@@ -587,10 +587,10 @@ putSequentialRealisticData(Args, Nrow, AccRow) ->
     Data = getRealisticData(<<"596044d8-86f5-462f-8d94-65b25e7d3fe9">>, StartTime + AccRow * Delta, LapsFrac),
 
 %%    case AccRow rem 10 of 
-%%	0 ->
-%%	    io:format("Putting row ~p Data = ~p~n", [AccRow, Data]);
-%%	_ ->
-%%	    ok
+%%      0 ->
+%%          io:format("Putting row ~p Data = ~p~n", [AccRow, Data]);
+%%      _ ->
+%%          ok
 %%    end,
 
     addKey(Ref, AccRow, Data, Enc),
@@ -602,39 +602,39 @@ getRealisticData(SportEventUuid, Timestamp, LapsFrac) ->
     LapsRand = random:uniform(1000),
     LapsComp = LapsFrac * 1000,
     Laps = 
-	case LapsRand =< LapsComp of
-	    true ->
-		10;
-	    false ->
-		-1
-	end,
-    [{<<"sport_event_uuid">>,	     SportEventUuid}, 
-     {<<"time">>,		     Timestamp}, 
-     {<<"club_uuid">>,		     list_to_binary(get_random_string(VarcharSize))},
-     {<<"person_uuid">>,	             list_to_binary(get_random_string(VarcharSize))},
-     {<<"sport_uuid">>,	             list_to_binary(get_random_string(VarcharSize))},
-     {<<"discipline_uuid">>,	     list_to_binary(get_random_string(VarcharSize))},
-     {<<"driver_number">>,	     list_to_binary(get_random_string(VarcharSize))},
-     {<<"person_full_name">>,	     list_to_binary(get_random_string(VarcharSize))},
-     {<<"club_full_name">>,	     list_to_binary(get_random_string(VarcharSize))},
-     {<<"abandoned">>,		     false},
-     {<<"best_gap_in_time">>,	     float(random:uniform(100))},
-     {<<"best_gap_in_lap">>,	     random:uniform(100)},
-     {<<"best_lap">>,		     float(random:uniform(100))},
-     {<<"best_position">>,	     random:uniform(100)},
-     {<<"best_sector_1">>,	     float(random:uniform(100))},
-     {<<"best_sector_2">>,	     float(random:uniform(100))},
-     {<<"best_sector_3">>,	     float(random:uniform(100))},
-     {<<"best_speed">>,	             float(random:uniform(100))},
-     {<<"gap_in_time">>,	             float(random:uniform(100))},
-     {<<"gap_in_lap">>,	             random:uniform(100)},
-     {<<"lap_timel">>,		     float(random:uniform(100))},
-     {<<"laps">>,		     Laps},
-     {<<"position">>,		     random:uniform(100)},
+        case LapsRand =< LapsComp of
+            true ->
+                10;
+            false ->
+                -1
+        end,
+    [{<<"sport_event_uuid">>,        SportEventUuid}, 
+     {<<"time">>,                    Timestamp}, 
+     {<<"club_uuid">>,               list_to_binary(get_random_string(VarcharSize))},
+     {<<"person_uuid">>,                     list_to_binary(get_random_string(VarcharSize))},
+     {<<"sport_uuid">>,              list_to_binary(get_random_string(VarcharSize))},
+     {<<"discipline_uuid">>,         list_to_binary(get_random_string(VarcharSize))},
+     {<<"driver_number">>,           list_to_binary(get_random_string(VarcharSize))},
+     {<<"person_full_name">>,        list_to_binary(get_random_string(VarcharSize))},
+     {<<"club_full_name">>,          list_to_binary(get_random_string(VarcharSize))},
+     {<<"abandoned">>,               false},
+     {<<"best_gap_in_time">>,        float(random:uniform(100))},
+     {<<"best_gap_in_lap">>,         random:uniform(100)},
+     {<<"best_lap">>,                float(random:uniform(100))},
+     {<<"best_position">>,           random:uniform(100)},
+     {<<"best_sector_1">>,           float(random:uniform(100))},
+     {<<"best_sector_2">>,           float(random:uniform(100))},
+     {<<"best_sector_3">>,           float(random:uniform(100))},
+     {<<"best_speed">>,              float(random:uniform(100))},
+     {<<"gap_in_time">>,                     float(random:uniform(100))},
+     {<<"gap_in_lap">>,              random:uniform(100)},
+     {<<"lap_timel">>,               float(random:uniform(100))},
+     {<<"laps">>,                    Laps},
+     {<<"position">>,                random:uniform(100)},
      {<<"qualification_position">>,   random:uniform(100)},
-     {<<"sector_1">>,		     float(random:uniform(100))},
-     {<<"sector_2">>,		     float(random:uniform(100))},
-     {<<"sector_3">>,		     float(random:uniform(100))},
+     {<<"sector_1">>,                float(random:uniform(100))},
+     {<<"sector_2">>,                float(random:uniform(100))},
+     {<<"sector_3">>,                float(random:uniform(100))},
      {<<"info">>,                    list_to_binary(get_random_string(VarcharSize))}].
 
 get_random_string(Length) ->
@@ -704,8 +704,8 @@ lteOps({Field, Val, Type, PutFn, EvalFn, OtherArgs}) ->
 
 allOps(Args) ->
     eqOps(Args) and eqEqOps(Args) and neqOps(Args) and 
-	gtOps(Args) and gteOps(Args) and
-	ltOps(Args) and lteOps(Args).
+        gtOps(Args) and gteOps(Args) and
+        ltOps(Args) and lteOps(Args).
 
 %------------------------------------------------------------
 % Only equality operations
@@ -721,7 +721,7 @@ eqOpsOnly(Args) ->
 
 allCompOps(Args) ->
     gtOps(Args) and gteOps(Args) and
-	ltOps(Args) and lteOps(Args).
+        ltOps(Args) and lteOps(Args).
 
 %------------------------------------------------------------
 % Any comparison operation
@@ -729,7 +729,7 @@ allCompOps(Args) ->
 
 anyCompOps(Args) ->
     gtOps(Args) or gteOps(Args) or
-	ltOps(Args) or lteOps(Args).
+        ltOps(Args) or lteOps(Args).
 
 %%=======================================================================
 %% Data-type specific tests
@@ -871,12 +871,12 @@ realisticOps(Enc) ->
     F = <<"laps">>,
     Val = 0,
     PutFn = 
-	case Enc of 
-	    msgpack ->
-		fun putKeyRealisticOpsMsgpack/1;
-	    _ ->
-		fun putKeyRealisticOpsErlang/1
-	end,
+        case Enc of 
+            msgpack ->
+                fun putKeyRealisticOpsMsgpack/1;
+            _ ->
+                fun putKeyRealisticOpsErlang/1
+        end,
     EvalFn = fun defaultEvalFn/1,
     Res = gteOps({F, {Val}, sint64, PutFn, EvalFn, []}),
     ?assert(Res),
@@ -941,12 +941,12 @@ orOps_test() ->
     {NTotal, NExpected3} = fieldsMatching(AllKeys, <<"f3">>, 4.0, fun(V1,V2) -> V1 == V2 end),
 
     NExpected =
-	case NExpected1 > NExpected3 of
-	    true ->
-		NExpected1;
-	    _ ->
-		NExpected3
-	end,
+        case NExpected1 > NExpected3 of
+            true ->
+                NExpected1;
+            _ ->
+                NExpected3
+        end,
 
     Keys = streamFoldTest(Filter, PutFn, []),
 
@@ -1201,7 +1201,7 @@ filterRefInvalidType_test() ->
 
 exceptionalTests() ->
     missingKey_test() and emptyKey_test() and filterRefMissingKey_test() and 
-	filterRefWrongType_test() and filterRefInvalidType_test().
+        filterRefWrongType_test() and filterRefInvalidType_test().
 
 %%=======================================================================
 %% Test scanning
@@ -1214,14 +1214,14 @@ exceptionalTests() ->
 streamFoldTestOpts(Opts, FoldFun) ->
     Ref = open(),
     try
-	Acc = eleveldb:fold(Ref, FoldFun, [], Opts),
-	ok = eleveldb:close(Ref),
-	Keys = lists:reverse(Acc)
+        Acc = eleveldb:fold(Ref, FoldFun, [], Opts),
+        ok = eleveldb:close(Ref),
+        Keys = lists:reverse(Acc)
     catch
-	error:Error ->
-	    io:format("Caught an error: closing db~n"),
-	    ok = eleveldb:close(Ref),
-	    error(Error)
+        error:Error ->
+            io:format("Caught an error: closing db~n"),
+            ok = eleveldb:close(Ref),
+            error(Error)
     end.
 
 %%------------------------------------------------------------
@@ -1237,13 +1237,13 @@ scanSome_test(Enc) ->
     N = 100,
     putKeysObj(N, Enc),
     Opts=[{fold_method, streaming},
-	  {start_key, <<"key002">>},
-	  {end_key,  <<"key099">>},
-	  {end_inclusive,  true}],
+          {start_key, <<"key002">>},
+          {end_key,  <<"key099">>},
+          {end_inclusive,  true}],
 
     FoldFun = fun({K,_V}, Acc) -> 
-		      [K | Acc]
-	      end,
+                      [K | Acc]
+              end,
 
     Keys = streamFoldTestOpts(Opts, FoldFun),
     Len = length(Keys),
@@ -1265,8 +1265,8 @@ scanAll_test(Enc) ->
     putKeysObj(N, Enc),
     Opts=[{fold_method, streaming}],
     FoldFun = fun({K,V}, Acc) -> 
-		      [getKeyVal(K,V) | Acc]
-	      end,
+                      [getKeyVal(K,V) | Acc]
+              end,
     Keys = streamFoldTestOpts(Opts, FoldFun),
     Len = length(Keys),
     Res = (Len =:= N),
@@ -1285,12 +1285,12 @@ scanNoStart_test(Enc) ->
     N = 100,
     putKeysObj(N, Enc),
     Opts=[{fold_method, streaming},
-	  {start_inclusive, false},
-	  {start_key, <<"key001">>}],
+          {start_inclusive, false},
+          {start_key, <<"key001">>}],
 
     FoldFun = fun({K,_V}, Acc) -> 
-		      [K | Acc]
-	      end,
+                      [K | Acc]
+              end,
 
     Keys = streamFoldTestOpts(Opts, FoldFun),
     [Key1 | _Rest] = Keys,
@@ -1303,12 +1303,12 @@ scanNoStartTest() ->
     N = 100,
     putKeysObj(N),
     Opts=[{fold_method, streaming},
-	  {start_inclusive, false},
-	  {start_key, <<"key001">>}],
+          {start_inclusive, false},
+          {start_key, <<"key001">>}],
 
     FoldFun = fun({K,_V}, Acc) -> 
-		      [K | Acc]
-	      end,
+                      [K | Acc]
+              end,
 
     streamFoldTestOpts(Opts, FoldFun).
 
@@ -1324,14 +1324,14 @@ scanNoStartOrEnd_test(Enc) ->
     N = 100,
     putKeysObj(N, Enc),
     Opts=[{fold_method, streaming},
-	  {start_inclusive, false},
-	  {end_inclusive, false},
-	  {start_key, <<"key001">>},
-	  {end_key,   <<"key100">>}],
+          {start_inclusive, false},
+          {end_inclusive, false},
+          {start_key, <<"key001">>},
+          {end_key,   <<"key100">>}],
 
     FoldFun = fun({K,_V}, Acc) -> 
-		      [K | Acc]
-	      end,
+                      [K | Acc]
+              end,
 
     Keys = streamFoldTestOpts(Opts, FoldFun),
 
@@ -1356,7 +1356,7 @@ scanTests() ->
 
 allTests() ->
     packObj_test() and normalOpsTests() and abnormalOpsTests() and exceptionalTests() 
-	and scanTests().
+        and scanTests().
 
 %%=======================================================================
 %% Test code to filter & decode TS keys from a leveldb table
@@ -1369,17 +1369,17 @@ readKeysFromTable(Table) ->
     Cond3 = {'>', {field, <<"time">>, timestamp}, {const,  9990000}},
     Filter = {'and_', Cond1, {'and_', Cond2, Cond3}},
     Opts=[{fold_method, streaming},
-	  {range_filter, Filter},
-	  {encoding, msgpack}],
+          {range_filter, Filter},
+          {encoding, msgpack}],
     io:format("Filter = ~p~n", [lists:flatten([Filter])]),
     TableName = "/Users/eml/projects/riak/riak_end_to_end_timeseries/dev/dev1/data/leveldb/" ++ Table,
     io:format("Attemping to open ~ts~n", [TableName]),
     Ref = open(TableName),
     Bucket = {<<"GeoCheckin">>, <<"GeoCheckin">>},
     FoldFun = fun({_K,V}, _Acc) -> 
-		      Contents = getKeyVal(Bucket, <<"key">>, V),
-		      io:format("Val = ~p~n", [lists:flatten(Contents)])
-	      end,
+                      Contents = getKeyVal(Bucket, <<"key">>, V),
+                      io:format("Val = ~p~n", [lists:flatten(Contents)])
+              end,
 
     eleveldb:fold(Ref, FoldFun, [], Opts),
     ok = eleveldb:close(Ref).


### PR DESCRIPTION
## **Overview**

This is one of two related PRs to replace msgpack with ttb as the default on-disk encoding format for TS.  The other is https://github.com/basho/riak_kv/pull/1510.

Msgpack was originally chosen as the encoding format because in early TS development (before the query pipeline was even written), micro-benchmarking of decoding riak objects in C++ for secondary filtering found that msgpack was significantly faster than naive implementation of the ei decoding library for ttb. In the context of the end-to-end query pipeline, however, that decoding in C++ represents less than 10% of the total query latency. Far and away the largest contribution to the latency is converting encoded records back to erlang terms in riak_kv_qry:decode_results() when they are returned to riak from eleveldb. In this context, the binary_to_term BIF is significantly more efficient than our implementation of msgpack decoding -- up to 30% faster for queries of 100K rows, and increasing with the size of the query.

You can find more discussion of the original micro-benchmarks, the query pipeline, and performance testing of this branch at https://github.com/basho/internal_wiki/wiki/Performance-Improvements-for-Riak#ts1.5.

The purpose of these PRs is to improve query performance by replacing msgpack with ttb encoding as the default on-disk format for TS data.
## **Changes in this repo**

**Summary** 
The class `RangeScanTask` defined in `workitems.h/cc`, is responsible for the streaming fold that executes a TS query.  When a secondary filter is passed in with the range scan options, the `RangeScanTask` constructor parses it into an expression tree that is vetted against each record on disk by decoding the record, populating the tree with values for the fields specified in the filter, and evaluating the tree.  Decoding the record is accomplished by an `Extractor` object which understands how to unpack a riak object and decode the data payload (defined in `extractor.h/cc`).

In previous versions of TS, only msgpack encoded records were legal, and the inherited class `ExtractorMsgpack` was used to decode all records.  That extractor lives inside the `RangeScanTask` object and was created when `RangeScanTask` was instantiated.  `ExtractorMsgpack` uses the class `CmpUtil` for all msgpack-related decoding operations, via the cmp library.

This PR adds a new inherited extractor, `ExtractorErlang` that decodes ttb-encoded records.  It uses the class `EiUtil` for all ttb-related decoding operations, via the ei library.   `EiUtil` is a direct analog of `CmpUtil` and is structured in much the same way.  

In this PR, `RangeScanTask` has been modified no longer to instantiate a single extractor object, but a _map_ of extractors for all valid encoding types.  When records are decoded, the encoding byte recorded with the riak object is used as an index into the map, to obtain the correct extractor for the current record.  In this way, the on-disk encoding no longer needs to be specified by the caller, and any mix of valid encodings can be processed seamlessly by the fold.

**Details**
`c_src/DataType.h` TTB encoding uses a special type ("small big") for large-integer encoding that must be handled separately from existing types, and a corresponding enum has been added here.

`c_src/EiUtil.h/cc` As mentioned in the summary above, `EiUtil` collects together all operations needed for decoding and formatting TTB-encoded data.  It is directly analogous to `CmpUtil` for msgpack, and is structured accordingly.  It is based on the erlang ei binary decoding interface, but one of the main methods used in the fold, `EiUtil::skipTerm` has been written from scratch, to avoid having to use ei decode calls to advance the index pointer when skipping over fields that are not part of the filter.  This replacement is responsible for a 4x speedup, making `ExtractorErlang` as fast as `ExtractorMsgpack` (see <a href=#perf>Performance</a> below)

`c_src/eleveldb.cc` Because we no longer make assumptions about the on-disk encoding format, but inspect each record as it's encountered, we no longer need the caller to specify an encoding.  The unused encoding atoms have therefore been removed, and the option -- if specified -- is simply ignored.

`c_src/ErlUtil.cc` When constructing error messages, I've changed the default behavior of `ErlUtil::formatTerm` to attempt to format binaries as human-readable strings, since most 'binaries' used in TS are actually strings to begin with.

`c_src/StringBuf.cc` A method has been added to return a C++ string version of the internal char\* buffer.

`c_src/exceptionutils.h` Not used in production code, but always useful during development, I'm adding a simple macro that allows dumping messages to disk.

`c_src/extractor.cc` The new inherited extractor `ExtractorErlang` has been added to this file, along with the `ExtractorMap` class for managing a map of extractors.  Base-class `riakObjectCanBeParsed` method has been modified to decode the encoding byte and check it against known valid encodings, and `extractRiakObject` has been moved into the baseclass.  In both `ExtractorErlang` and `ExtractorMsgpack` an additional check has been added that stops the decoding when all fields referenced by the filter have been encountered.  This further optimizes performance for long records by only decoding the part of the object we need to evaluate the filter.

`c_src/filter.h` I realized that by allowing NULLs, we had introduced a logical error in evaluation of binary AND and OR expressions.  When NULLs were not allowed, we checked if each operand to the binary expressions had a value, and the expression evaluated to false if either didn't.  Since has_value() is now used to indicate a valid NULL value, these checks must be removed, and both operands must be evaluated.

`c_src/filter_parser.h/cc` Because the single extractor has been changed to an `ExtractorMap` type, every method of filter_parser has been changed to take an `ExtractorMap&` argument instead.  When fields are added by a filter condition, they are now added to every extractor in the map, since we do not know up-front which ones will be needed during the fold.

`c_src/workitems.h` As discussed in the summary above, `RangeScanTask` has been modified to manage a map of extractors, rather than a single extractor, and `RangeScanTask::DoWork` now looks up the right extractor in the map for each disk record on the fly.  All code related to parsing the deprecated encoding type from the filter options has been removed.

`test/sut.erl` Changes to test filtering over interleaved msgpack and ttb-encoded records, and to provide coverage for decoding any integer data type that may be encountered.  Previous version of sut.erl tested integer operations, but only for small ints.  For both msgpack and ttb, integers can be encoded as a variety of types depending on value, and the current test therefore explicitly tests all regimes to exercise this behavior.  Finally, tests for invalid encoding specification have been removed, since specifying an encoding is no longer required, and an invalid encoding therefore no longer generates an error.
## **Compatibility**

**Backwards Compatibility** Because the new code uses the on-disk encoding flag to determine which extractor to use, data previously written in msgpack format will continue to be correctly interpreted in TS1.5.  As noted in https://github.com/basho/riak_kv/pull/1510, the riak_kv code is also agnostic as to the encoding, and will correctly handle records returned to erlang in either format.

**Downgrade Compatibility** Because the riak_kv code is agnostic (already handles TTB data for KV records), older versions of TS will correctly interpret TS data written with ttb encoding.  As noted in https://github.com/basho/riak_kv/pull/1510, however, if a customer downgrades to TS1.4 after writting data with TS1.5, they would need this version of eleveldb or the ttb-encoded records would be skipped.  Older versions of riak_kv will work with this version of eleveldb, since the deprecated encoding option is quietly ignored if specified.
## <a name=perf>**Performance**</a>

In addition to the functional testing coverage in `sut.erl`, extensive testing of this branch is detailed at https://github.com/basho/internal_wiki/wiki/Performance-Improvements-for-Riak#ts1.5.  I reproduce a summary plot here:

![msg_ttb_filter_cmp](https://cloud.githubusercontent.com/assets/9666459/19581450/e040e8c2-96e1-11e6-8713-634654829ae4.png)

The plot shows latencies for TS1.4 (left panel), this branch (middle panel), and the difference in ms (right panel), for a wide range of query sizes using secondary filtering.  The plot demonstrates two important points:
- on the short-query side (Nrow < 100), where the latency is dominated by the actual eleveldb fold operation, the difference is consistent with zero, demonstrating that the ttb decoding is as efficient as the msgpack decoding in C++
- on the large-query side (Nrow > 100), where the latency is dominated by decoding of returned records in erlang, this branch is more than 30% faster than TS1.4 -- for example the reduction in latency for 100K-row queries is 700 ms (out of ~2 seconds).
