### PR TITLE
Disable shared library creation

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -67,7 +67,7 @@ case "$1" in
     *)
         if [ ! -d snappy-$SNAPPY_VSN ]; then
             tar -xzf snappy-$SNAPPY_VSN.tar.gz
-            (cd snappy-$SNAPPY_VSN && ./configure --prefix=$BASEDIR/system --libdir=$BASEDIR/system/lib --with-pic)
+            (cd snappy-$SNAPPY_VSN && ./configure --disable-shared --prefix=$BASEDIR/system --libdir=$BASEDIR/system/lib --with-pic)
         fi
 
         if [ ! -f system/lib/libsnappy.a ]; then


### PR DESCRIPTION
Manually disabling dylib creation for snappy since OSX links the preferentially rather than the static library.  This resolves https://github.com/basho/eleveldb/issues/236