### PR TITLE
Test cleanup

### DIFF
--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -1,8 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%%  eleveldb: Erlang Wrapper for LevelDB (http://code.google.com/p/leveldb/)
-%%
-%% Copyright (c) 2010-2012 Basho Technologies, Inc. All Rights Reserved.
+%% Copyright (c) 2010-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,6 +17,8 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
+%% @doc Erlang NIF wrapper for LevelDB
 -module(eleveldb).
 
 -export([open/2,
@@ -49,11 +49,17 @@
 -on_load(init/0).
 
 -ifdef(TEST).
--compile(export_all).
+-export([
+    assert_close/1,
+    assert_open/1,
+    assert_open/2,
+    create_test_dir/0,
+    delete_test_dir/1,
+    terminal_format/2
+]).
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--define(QC_OUT(P),
-        eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
+-define(QC_OUT(P), eqc:on_output(fun terminal_format/2, P)).
 -endif.
 -include_lib("eunit/include/eunit.hrl").
 -endif.
@@ -370,7 +376,12 @@ do_fold(Itr, Fun, Acc0, Opts) ->
         true = is_binary(Start) or (Start == first),
         fold_loop(iterator_move(Itr, Start), Itr, Fun, Acc0)
     after
-        iterator_close(Itr)
+        %% This clause shouldn't change the operation's result.
+        %% If the iterator has been invalidated by it or the db being closed,
+        %% the try clause above will raise an exception, and that's the one we
+        %% want to propagate. Catch the exception this raises in that case and
+        %% ignore it so we don't obscure the original.
+        catch iterator_close(Itr)
     end.
 
 fold_loop({error, iterator_closed}, _Itr, _Fun, Acc0) ->
@@ -395,105 +406,253 @@ validate_type(_, _)                                          -> false.
 
 
 %% ===================================================================
-%% EUnit tests
+%% Tests
 %% ===================================================================
 -ifdef(TEST).
 
-open_test() -> [{open_test_Z(), l} || l <- lists:seq(1, 20)].
-open_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.open.test"),
-    {ok, Ref} = open("/tmp/eleveldb.open.test", [{create_if_missing, true}]),
-    ok = ?MODULE:put(Ref, <<"abc">>, <<"123">>, []),
-    {ok, <<"123">>} = ?MODULE:get(Ref, <<"abc">>, []),
-    not_found = ?MODULE:get(Ref, <<"def">>, []).
+%% ===================================================================
+%% Exported Test Helpers
+%% ===================================================================
 
-fold_test() -> [{fold_test_Z(), l} || l <- lists:seq(1, 20)].
-fold_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.fold.test"),
-    {ok, Ref} = open("/tmp/eleveldb.fold.test", [{create_if_missing, true}]),
-    ok = ?MODULE:put(Ref, <<"def">>, <<"456">>, []),
-    ok = ?MODULE:put(Ref, <<"abc">>, <<"123">>, []),
-    ok = ?MODULE:put(Ref, <<"hij">>, <<"789">>, []),
-    [{<<"abc">>, <<"123">>},
-     {<<"def">>, <<"456">>},
-     {<<"hij">>, <<"789">>}] = lists:reverse(fold(Ref, fun({K, V}, Acc) -> [{K, V} | Acc] end,
-                                                  [], [])).
+-spec assert_close(DbRef :: db_ref()) -> ok | no_return().
+%
+% Closes DbRef inside an ?assert... macro.
+%
+assert_close(DbRef) ->
+    ?assertEqual(ok, ?MODULE:close(DbRef)).
 
-fold_keys_test() -> [{fold_keys_test_Z(), l} || l <- lists:seq(1, 20)].
-fold_keys_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.fold.keys.test"),
-    {ok, Ref} = open("/tmp/eleveldb.fold.keys.test", [{create_if_missing, true}]),
-    ok = ?MODULE:put(Ref, <<"def">>, <<"456">>, []),
-    ok = ?MODULE:put(Ref, <<"abc">>, <<"123">>, []),
-    ok = ?MODULE:put(Ref, <<"hij">>, <<"789">>, []),
-    [<<"abc">>, <<"def">>, <<"hij">>] = lists:reverse(fold_keys(Ref,
-                                                                fun(K, Acc) -> [K | Acc] end,
-                                                                [], [])).
+-spec assert_open(DbPath :: string()) -> db_ref() | no_return().
+%
+% Opens Path inside an ?assert... macro, creating the database directory if needed.
+%
+assert_open(DbPath) ->
+    assert_open(DbPath, [{create_if_missing, true}]).
 
-fold_from_key_test() -> [{fold_from_key_test_Z(), l} || l <- lists:seq(1, 20)].
-fold_from_key_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.fold.fromkeys.test"),
-    {ok, Ref} = open("/tmp/eleveldb.fromfold.keys.test", [{create_if_missing, true}]),
-    ok = ?MODULE:put(Ref, <<"def">>, <<"456">>, []),
-    ok = ?MODULE:put(Ref, <<"abc">>, <<"123">>, []),
-    ok = ?MODULE:put(Ref, <<"hij">>, <<"789">>, []),
-    [<<"def">>, <<"hij">>] = lists:reverse(fold_keys(Ref,
-                                                     fun(K, Acc) -> [K | Acc] end,
-                                                     [], [{first_key, <<"d">>}])).
+-spec assert_open(DbPath :: string(), OpenOpts :: open_options())
+            -> db_ref() | no_return().
+%
+% Opens DbPath, with OpenOpts, inside an ?assert... macro.
+%
+assert_open(DbPath, OpenOpts) ->
+    OpenRet = ?MODULE:open(DbPath, OpenOpts),
+    ?assertMatch({ok, _}, OpenRet),
+    {_, DbRef} = OpenRet,
+    DbRef.
 
-destroy_test() -> [{destroy_test_Z(), l} || l <- lists:seq(1, 20)].
-destroy_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.destroy.test"),
-    {ok, Ref} = open("/tmp/eleveldb.destroy.test", [{create_if_missing, true}]),
-    ok = ?MODULE:put(Ref, <<"def">>, <<"456">>, []),
-    {ok, <<"456">>} = ?MODULE:get(Ref, <<"def">>, []),
-    close(Ref),
-    ok = ?MODULE:destroy("/tmp/eleveldb.destroy.test", []),
-    {error, {db_open, _}} = open("/tmp/eleveldb.destroy.test", [{error_if_exists, true}]).
+-spec create_test_dir() -> string() | no_return().
+%
+% Creates a new, empty, uniquely-named directory for testing and returns
+% its full path. This operation *should* never fail, but would raise an
+% ?assert...-ish exception if it did.
+%
+create_test_dir() ->
+    string:strip(?cmd("mktemp -d /tmp/" ?MODULE_STRING ".XXXXXXX"), both, $\n).
 
-compression_test() -> [{compression_test_Z(), l} || l <- lists:seq(1, 20)].
-compression_test_Z() ->
-    CompressibleData = list_to_binary([0 || _X <- lists:seq(1,20)]),
-    os:cmd("rm -rf /tmp/eleveldb.compress.0 /tmp/eleveldb.compress.1"),
-    {ok, Ref0} = open("/tmp/eleveldb.compress.0", [{write_buffer_size, 5},
-                                                   {create_if_missing, true},
-                                                   {compression, false}]),
-    [ok = ?MODULE:put(Ref0, <<I:64/unsigned>>, CompressibleData, [{sync, true}]) ||
-        I <- lists:seq(1,10)],
-    {ok, Ref1} = open("/tmp/eleveldb.compress.1", [{write_buffer_size, 5},
-                                                   {create_if_missing, true},
-                                                   {compression, true}]),
-    [ok = ?MODULE:put(Ref1, <<I:64/unsigned>>, CompressibleData, [{sync, true}]) ||
-        I <- lists:seq(1,10)],
-	%% Check both of the LOG files created to see if the compression option was correctly
-	%% passed down
-	MatchCompressOption =
-		fun(File, Expected) ->
-				{ok, Contents} = file:read_file(File),
-				case re:run(Contents, "Options.compression: " ++ Expected) of
-					{match, _} -> match;
-					nomatch -> nomatch
-				end
-		end,
-	Log0Option = MatchCompressOption("/tmp/eleveldb.compress.0/LOG", "0"),
-	Log1Option = MatchCompressOption("/tmp/eleveldb.compress.1/LOG", "1"),
-	?assert(Log0Option =:= match andalso Log1Option =:= match).
+-spec delete_test_dir(Dir :: string()) -> ok | no_return().
+%
+% Deletes a test directory fully, whether or not it exists.
+% This operation *should* never fail, but would raise an ?assert...-ish
+% exception if it did.
+%
+delete_test_dir(Dir) ->
+    ?assertCmd("rm -rf " ++ Dir).
 
+-spec terminal_format(Fmt :: io:format(), Args :: list()) -> ok.
+%
+% Writes directly to the terminal, bypassing EUnit hooks.
+%
+terminal_format(Fmt, Args) ->
+    io:format(user, Fmt, Args).
 
-close_test() -> [{close_test_Z(), l} || l <- lists:seq(1, 20)].
-close_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.close.test"),
-    {ok, Ref} = open("/tmp/eleveldb.close.test", [{create_if_missing, true}]),
-    ?assertEqual(ok, close(Ref)),
-    ?assertEqual({error, einval}, close(Ref)).
+%% ===================================================================
+%% EUnit Tests
+%% ===================================================================
 
-close_fold_test() -> [{close_fold_test_Z(), l} || l <- lists:seq(1, 20)].
-close_fold_test_Z() ->
-    os:cmd("rm -rf /tmp/eleveldb.close_fold.test"),
-    {ok, Ref} = open("/tmp/eleveldb.close_fold.test", [{create_if_missing, true}]),
-    ok = eleveldb:put(Ref, <<"k">>,<<"v">>,[]),
-    ?assertException(throw, {iterator_closed, ok}, % ok is returned by close as the acc
-                     eleveldb:fold(Ref, fun(_,_A) -> eleveldb:close(Ref) end, undefined, [])).
+-define(local_test(TestFunc),
+    fun(TestRoot) ->
+        Title = erlang:atom_to_list(TestFunc),
+        TestDir = filename:join(TestRoot, TestFunc),
+        {Title, fun() -> TestFunc(TestDir) end}
+    end
+).
+
+eleveldb_test_() ->
+    {foreach,
+        fun create_test_dir/0,
+        fun delete_test_dir/1,
+        [
+            ?local_test(test_open),
+            ?local_test(test_close),
+            ?local_test(test_destroy),
+            ?local_test(test_open_many),
+            ?local_test(test_fold),
+            ?local_test(test_fold_keys),
+            ?local_test(test_fold_from_key),
+            ?local_test(test_close_fold),
+            ?local_test(test_compression)
+        ]
+    }.
+
+% fold accumulator used in a few tests
+accumulate(Val, Acc) ->
+    [Val | Acc].
+
+%
+% Individual tests
+%
+
+test_open(TestDir) ->
+    Ref = assert_open(TestDir),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"abc">>, <<"123">>, [])),
+    ?assertEqual({ok, <<"123">>}, ?MODULE:get(Ref, <<"abc">>, [])),
+    ?assertEqual(not_found, ?MODULE:get(Ref, <<"def">>, [])),
+    assert_close(Ref).
+
+test_open_many(TestDir) ->
+    HowMany = 33,
+    Insts   = lists:seq(1, HowMany),
+    KNonce  = erlang:make_ref(),
+    VNonce  = erlang:self(),
+    WorkSet = [{
+        assert_open(lists:flatten(io_lib:format("~s.~b", [TestDir, N]))),
+        erlang:integer_to_binary(erlang:phash2([os:timestamp(), KNonce, N])),
+        erlang:integer_to_binary(erlang:phash2([os:timestamp(), VNonce, N]))}
+        || N <- Insts],
+    lists:foreach(
+        fun({Ref, Key, Val}) ->
+            ?assertEqual(ok, ?MODULE:put(Ref, Key, Val, []))
+        end, WorkSet),
+    lists:foreach(
+        fun({Ref, Key, Val}) ->
+            ?assertEqual({ok, Val}, ?MODULE:get(Ref, Key, []))
+        end, WorkSet),
+    lists:foreach(fun assert_close/1, [R || {R, _, _} <- WorkSet]).
+
+test_close(TestDir) ->
+    Ref = assert_open(TestDir, [{create_if_missing, true}]),
+    assert_close(Ref),
+    ?assertError(badarg, ?MODULE:close(Ref)).
+
+test_fold(TestDir) ->
+    Ref = assert_open(TestDir),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"def">>, <<"456">>, [])),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"abc">>, <<"123">>, [])),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"hij">>, <<"789">>, [])),
+    ?assertEqual(
+        [{<<"abc">>, <<"123">>}, {<<"def">>, <<"456">>}, {<<"hij">>, <<"789">>}],
+        lists:reverse(?MODULE:fold(Ref, fun accumulate/2, [], []))),
+    assert_close(Ref).
+
+test_fold_keys(TestDir) ->
+    Ref = assert_open(TestDir),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"def">>, <<"456">>, [])),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"abc">>, <<"123">>, [])),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"hij">>, <<"789">>, [])),
+    ?assertEqual(
+        [<<"abc">>, <<"def">>, <<"hij">>],
+        lists:reverse(?MODULE:fold_keys(Ref, fun accumulate/2, [], []))),
+    assert_close(Ref).
+
+test_fold_from_key(TestDir) ->
+    Ref = assert_open(TestDir),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"def">>, <<"456">>, [])),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"abc">>, <<"123">>, [])),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"hij">>, <<"789">>, [])),
+    ?assertEqual([<<"def">>, <<"hij">>], lists:reverse(
+        ?MODULE:fold_keys(Ref, fun accumulate/2, [], [{first_key, <<"d">>}]))),
+    assert_close(Ref).
+
+test_destroy(TestDir) ->
+    Ref = assert_open(TestDir),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"def">>, <<"456">>, [])),
+    ?assertEqual({ok, <<"456">>}, ?MODULE:get(Ref, <<"def">>, [])),
+    assert_close(Ref),
+    ?assertEqual(ok, ?MODULE:destroy(TestDir, [])),
+    ?assertMatch({error, {db_open, _}}, ?MODULE:open(TestDir, [{error_if_exists, true}])).
+
+test_compression(TestDir) ->
+    IntSeq = lists:seq(1, 10),
+    CompressibleData = list_to_binary(lists:duplicate(20, 0)),
+
+    Ref0 = assert_open(TestDir ++ ".0", [
+        {write_buffer_size, 5}, {create_if_missing, true}, {compression, false}]),
+    lists:foreach(
+        fun(I) ->
+            ?assertEqual(ok,
+                ?MODULE:put(Ref0, <<I:64/unsigned>>, CompressibleData, [{sync, true}]))
+        end, IntSeq),
+
+    Ref1 = assert_open(TestDir ++ ".1", [
+        {write_buffer_size, 5}, {create_if_missing, true}, {compression, true}]),
+    lists:foreach(
+        fun(I) ->
+            ?assertEqual(ok,
+                ?MODULE:put(Ref1, <<I:64/unsigned>>, CompressibleData, [{sync, true}]))
+        end, IntSeq),
+
+    %% Check both of the LOG files created to see if the compression option was
+    %% passed down correctly
+    lists:foreach(
+        fun(Val) ->
+            File = filename:join(TestDir ++ [$. | Val], "LOG"),
+            RRet = file:read_file(File),
+            ?assertMatch({ok, _}, RRet),
+            {_, Data} = RRet,
+            Pattern = "Options.compression: " ++ Val,
+            ?assertMatch({match, _}, re:run(Data, Pattern))
+        end, ["0", "1"]),
+    assert_close(Ref0),
+    assert_close(Ref1).
+
+test_close_fold(TestDir) ->
+    Ref = assert_open(TestDir),
+    ?assertEqual(ok, ?MODULE:put(Ref, <<"k">>,<<"v">>,[])),
+    ?assertError(badarg,
+        ?MODULE:fold(Ref, fun(_,_) -> assert_close(Ref) end, undefined, [])).
+
+%
+% Parallel tests
+%
+
+parallel_test_() ->
+    ParaCnt = (erlang:system_info(schedulers) * 2 + 1),
+    LoadCnt = 199,
+    TestSeq = lists:seq(1, ParaCnt),
+    {foreach,
+        fun create_test_dir/0,
+        fun delete_test_dir/1,
+        [fun(TestRoot) ->
+            {inparallel, [begin
+                T = lists:flatten(io_lib:format("load proc ~b", [N])),
+                D = filename:join(TestRoot, io_lib:format("parallel_test.~b", [N])),
+                S = lists:seq(N, (N + LoadCnt - 1)),
+                {T, fun() -> run_load(D, S) end}
+            end || N <- TestSeq]}
+        end]
+    }.
+
+run_load(TestDir, IntSeq) ->
+    Nonce   = [os:timestamp(), erlang:self()],
+    KVIn    = [{
+        erlang:integer_to_binary(erlang:phash2([erlang:make_ref(), N | Nonce])),
+        erlang:integer_to_binary(erlang:phash2([N, erlang:make_ref() | Nonce]))
+        } || N <- IntSeq],
+    {L, R}  = lists:split(erlang:hd(IntSeq), KVIn),
+    KVOut   = R ++ L,
+    Ref     = assert_open(TestDir),
+    lists:foreach(
+        fun({Key, Val}) ->
+            ?assertEqual(ok, ?MODULE:put(Ref, Key, Val, []))
+        end, KVIn),
+    lists:foreach(
+        fun({Key, Val}) ->
+            ?assertEqual({ok, Val}, ?MODULE:get(Ref, Key, []))
+        end, KVOut),
+    assert_close(Ref).
+
+%% ===================================================================
+%% QuickCheck Tests
+%% ===================================================================
 
 -ifdef(EQC).
 
@@ -512,56 +671,81 @@ ops(Keys, Values) ->
 apply_kv_ops([], _Ref, Acc0) ->
     Acc0;
 apply_kv_ops([{put, K, V} | Rest], Ref, Acc0) ->
-    ok = eleveldb:put(Ref, K, V, []),
+    ?assertEqual(ok, ?MODULE:put(Ref, K, V, [])),
     apply_kv_ops(Rest, Ref, orddict:store(K, V, Acc0));
 apply_kv_ops([{async_put, K, V} | Rest], Ref, Acc0) ->
     MyRef = make_ref(),
     Context = {my_context, MyRef},
-    ok = eleveldb:async_put(Ref, Context, K, V, []),
+    ?assertEqual(ok, ?MODULE:async_put(Ref, Context, K, V, [])),
     receive
         {Context, ok} ->
             apply_kv_ops(Rest, Ref, orddict:store(K, V, Acc0));
         Msg ->
-            error({unexpected_msg, Msg})
+            erlang:error({unexpected_msg, Msg})
     end;
 apply_kv_ops([{delete, K, _} | Rest], Ref, Acc0) ->
-    ok = eleveldb:delete(Ref, K, []),
+    ?assertEqual(ok, ?MODULE:delete(Ref, K, [])),
     apply_kv_ops(Rest, Ref, orddict:store(K, deleted, Acc0)).
 
-prop_put_delete() ->
+prop_put_delete(TestDir) ->
     ?LET({Keys, Values}, {keys(), values()},
-         ?FORALL(Ops, eqc_gen:non_empty(list(ops(Keys, Values))),
-                 begin
-                     ?cmd("rm -rf /tmp/eleveldb.putdelete.qc"),
-                     {ok, Ref} = eleveldb:open("/tmp/eleveldb.putdelete.qc",
-                                                [{create_if_missing, true}]),
-                     Model = apply_kv_ops(Ops, Ref, []),
+        ?FORALL(Ops, eqc_gen:non_empty(list(ops(Keys, Values))),
+            begin
+                delete_test_dir(TestDir),
+                Ref = assert_open(TestDir, [{create_if_missing, true}]),
+                Model = apply_kv_ops(Ops, Ref, []),
 
-                     %% Valdiate that all deleted values return not_found
-                     F = fun({K, deleted}) ->
-                                 ?assertEqual(not_found, eleveldb:get(Ref, K, []));
-                            ({K, V}) ->
-                                 ?assertEqual({ok, V}, eleveldb:get(Ref, K, []))
-                         end,
-                     lists:map(F, Model),
+                %% Validate that all deleted values return not_found
+                lists:foreach(
+                    fun({K, deleted}) ->
+                        ?assertEqual(not_found, ?MODULE:get(Ref, K, []));
+                    ({K, V}) ->
+                        ?assertEqual({ok, V}, ?MODULE:get(Ref, K, []))
+                end, Model),
 
-                     %% Validate that a fold returns sorted values
-                     Actual = lists:reverse(fold(Ref, fun({K, V}, Acc) -> [{K, V} | Acc] end,
-                                                 [], [])),
-                     ?assertEqual([{K, V} || {K, V} <- Model, V /= deleted],
-                                  Actual),
-                     ok = eleveldb:close(Ref),
-                     true
-                 end)).
+                %% Validate that a fold returns sorted values
+                Actual = lists:reverse(
+                    ?MODULE:fold(Ref, fun({K, V}, Acc) -> [{K, V} | Acc] end, [], [])),
+                ?assertEqual([{K, V} || {K, V} <- Model, V /= deleted], Actual),
+                assert_close(Ref),
+                true
+            end)).
 
 prop_put_delete_test_() ->
     Timeout1 = 10,
     Timeout2 = 15,
-    %% We use the ?ALWAYS(300, ...) wrapper around the second test as a
-    %% regression test.
-    [{timeout, 3*Timeout1, {"No ?ALWAYS()", fun() -> qc(eqc:testing_time(Timeout1,prop_put_delete())) end}},
-     {timeout, 10*Timeout2, {"With ?ALWAYS()", fun() -> qc(eqc:testing_time(Timeout2,?ALWAYS(150,prop_put_delete()))) end}}].
+    {foreach,
+        fun create_test_dir/0,
+        fun delete_test_dir/1,
+        [
+            fun(TestRoot) ->
+                TestDir = filename:join(TestRoot, "putdelete.qc"),
+                InnerTO = Timeout1,
+                OuterTO = (InnerTO * 3),
+                Title   = "Without ?ALWAYS()",
+                TestFun = fun() ->
+                    qc(eqc:testing_time(InnerTO, prop_put_delete(TestDir)))
+                end,
+                {timeout, OuterTO, {Title, TestFun}}
+            end,
+            fun(TestRoot) ->
+                TestDir = filename:join(TestRoot, "putdelete.qc"),
+                InnerTO = Timeout2,
+                OuterTO = (InnerTO * 10),
+                AwCount = (InnerTO * 9),
+                %% We use the ?ALWAYS(AwCount, ...) wrapper as a regression test.
+                %% It's not clear how this is effectively different than the first
+                %% fixture, but I'm leaving it here in case I'm missing something.
+                Title   = lists:flatten(io_lib:format("With ?ALWAYS(~b)", [AwCount])),
+                TestFun = fun() ->
+                    qc(eqc:testing_time(InnerTO,
+                        ?ALWAYS(AwCount, prop_put_delete(TestDir))))
+                end,
+                {timeout, OuterTO, {Title, TestFun}}
+            end
+        ]
+    }.
 
--endif.
+-endif. % EQC
 
--endif.
+-endif. % TEST

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -488,13 +488,25 @@ eleveldb_test_() ->
             ?local_test(test_fold_keys),
             ?local_test(test_fold_from_key),
             ?local_test(test_close_fold),
-            ?local_test(test_compression),
+            % On weak machines the following can take a while, so we tweak
+            % them a bit to avoid timeouts. On anything resembling a competent
+            % computer, these should complete in a small fraction of a second,
+            % well under the default 5 second timeout, but on lightweight VMs
+            % used for validation, that can be extended by orders of magnitude.
+            % Anything that can't run a test that should complete comfortably
+            % in a tenth of a second within 150 times that doesn't deserve to
+            % be called a computer.
             fun(TestRoot) ->
-                TestFunc = test_open_many,
-                TestDir = filename:join(TestRoot, TestFunc),
+                TestName = "test_compression",
+                TestDir = filename:join(TestRoot, TestName),
+                {TestName, {timeout, 15, fun() -> test_compression(TestDir) end}}
+            end,
+            fun(TestRoot) ->
+                TestName = "test_open_many",
+                TestDir = filename:join(TestRoot, TestName),
                 Count = (erlang:system_info(schedulers) * 4 + 1),
-                Title = lists:flatten(io_lib:format("~s(~b)", [TestFunc, Count])),
-                {Title, fun() -> test_open_many(TestDir, Count) end}
+                Title = lists:flatten(io_lib:format("~s(~b)", [TestName, Count])),
+                {Title, {timeout, 15, fun() -> test_open_many(TestDir, Count) end}}
             end
         ]
     }.

--- a/src/eleveldb.erl
+++ b/src/eleveldb.erl
@@ -484,12 +484,18 @@ eleveldb_test_() ->
             ?local_test(test_open),
             ?local_test(test_close),
             ?local_test(test_destroy),
-            ?local_test(test_open_many),
             ?local_test(test_fold),
             ?local_test(test_fold_keys),
             ?local_test(test_fold_from_key),
             ?local_test(test_close_fold),
-            ?local_test(test_compression)
+            ?local_test(test_compression),
+            fun(TestRoot) ->
+                TestFunc = test_open_many,
+                TestDir = filename:join(TestRoot, TestFunc),
+                Count = (erlang:system_info(schedulers) * 4 + 1),
+                Title = lists:flatten(io_lib:format("~s(~b)", [TestFunc, Count])),
+                {Title, fun() -> test_open_many(TestDir, Count) end}
+            end
         ]
     }.
 
@@ -508,8 +514,7 @@ test_open(TestDir) ->
     ?assertEqual(not_found, ?MODULE:get(Ref, <<"def">>, [])),
     assert_close(Ref).
 
-test_open_many(TestDir) ->
-    HowMany = 33,
+test_open_many(TestDir, HowMany) ->
     Insts   = lists:seq(1, HowMany),
     KNonce  = erlang:make_ref(),
     VNonce  = erlang:self(),

--- a/test/cacheleak.erl
+++ b/test/cacheleak.erl
@@ -1,8 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%%  eleveldb: Erlang Wrapper for LevelDB (http://code.google.com/p/leveldb/)
-%%
-%% Copyright (c) 2010-2013 Basho Technologies, Inc. All Rights Reserved.
+%% Copyright (c) 2012-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,44 +17,61 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
 -module(cacheleak).
 
--compile(export_all).
-
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+-define(KV_PAIRS,   (1000 * 10)).
+-define(VAL_SIZE,   (1024 * 10)).
+-define(MAX_RSS,    (1000 * 500)).  % driven by ?KV_PAIRS and ?VAL_SIZE ?
+
+-define(TEST_LOOPS, 10).
+-define(TIMEOUT,    (?TEST_LOOPS * 60)).
+
 cacheleak_test_() ->
-    {timeout, 10*60, fun() ->
-                              [] = os:cmd("rm -rf /tmp/eleveldb.cacheleak.test"),
-                              Blobs = [{<<I:128/unsigned>>, compressible_bytes(10240)} ||
-                                          I <- lists:seq(1, 10000)],
-                              cacheleak_loop(10, Blobs, 500000)
-                      end}.
+    TestRoot = eleveldb:create_test_dir(),
+    TestDir = filename:join(TestRoot, ?MODULE),
+    {setup,
+        fun() -> TestRoot end,
+        fun eleveldb:delete_test_dir/1,
+        {timeout, ?TIMEOUT, fun() ->
+            Bytes = compressible_bytes(?VAL_SIZE),
+            Blobs = [{<<I:128/unsigned>>, Bytes} || I <- lists:seq(1, ?KV_PAIRS)],
+            eleveldb:terminal_format("RSS limit: ~b\n", [?MAX_RSS]),
+            cacheleak_loop(?TEST_LOOPS, Blobs, ?MAX_RSS, TestDir)
+        end}}.
 
 %% It's very important for this test that the data is compressible. Otherwise,
-%% the file will be mmaped, and nothing will fill up the cache.
+%% the file will be mmapped, and nothing will fill up the cache.
 compressible_bytes(Count) ->
-    list_to_binary([0 || _I <- lists:seq(1, Count)]).
+    erlang:list_to_binary(lists:duplicate(Count, 0)).
 
-cacheleak_loop(0, _Blobs, _MaxFinalRSS) ->
+cacheleak_loop(0, _Blobs, _MaxFinalRSS, _TestDir) ->
     ok;
-cacheleak_loop(Count, Blobs, MaxFinalRSS) ->
+cacheleak_loop(Count, Blobs, MaxFinalRSS, TestDir) ->
     %% We spawn a process to open a LevelDB instance and do a series of
     %% reads/writes to fill up the cache. When the process exits, the LevelDB
     %% ref will get GC'd and we can re-evaluate the memory footprint of the
     %% process to make sure everything got cleaned up as expected.
     F = fun() ->
-
-                {ok, Ref} = eleveldb:open("/tmp/eleveldb.cacheleak.test",
-                                          [{create_if_missing, true},
-                                           {limited_developer_mem, true}]),
-                [ok = eleveldb:put(Ref, I, B, []) || {I, B} <- Blobs],
-                eleveldb:fold(Ref, fun({_K, _V}, A) -> A end, [], [{fill_cache, true}]),
-                [{ok, B} = eleveldb:get(Ref, I, []) || {I, B} <- Blobs],
-                ok = eleveldb:close(Ref),
-                erlang:garbage_collect(),
-                io:format(user, "RSS1: ~p\n", [rssmem()])
-        end,
+        Ref = eleveldb:assert_open(TestDir,
+            [{create_if_missing, true}, {limited_developer_mem, true}]),
+        lists:foreach(
+            fun({Key, Val}) ->
+                ?assertEqual(ok, eleveldb:put(Ref, Key, Val, []))
+            end, Blobs),
+        ?assertEqual([], eleveldb:fold(Ref,
+            fun({_K, _V}, A) -> A end, [], [{fill_cache, true}])),
+        lists:foreach(
+            fun({Key, Val}) ->
+                ?assertEqual({ok, Val}, eleveldb:get(Ref, Key, []))
+            end, Blobs),
+        eleveldb:assert_close(Ref),
+        erlang:garbage_collect(),
+        eleveldb:terminal_format("RSS1: ~p\n", [rssmem()])
+    end,
     {_Pid, Mref} = spawn_monitor(F),
     receive
         {'DOWN', Mref, process, _, _} ->
@@ -64,15 +79,18 @@ cacheleak_loop(Count, Blobs, MaxFinalRSS) ->
     end,
     RSS = rssmem(),
     ?assert(MaxFinalRSS > RSS),
-    cacheleak_loop(Count-1, Blobs, MaxFinalRSS).
+    cacheleak_loop(Count - 1, Blobs, MaxFinalRSS, TestDir).
 
 rssmem() ->
     Cmd = io_lib:format("ps -o rss= -p ~s", [os:getpid()]),
-    S = string:strip(os:cmd(Cmd), both),
+    % Don't try to use eunit's ?cmd macro here, it won't do the right thing.
+    S = string:strip(os:cmd(Cmd), left),  % only matters that the 1st character is $0-$9
     case string:to_integer(S) of
         {error, _} ->
-            io:format(user, "Error parsing integer in: ~s\n", [S]),
+            eleveldb:terminal_format("Error parsing integer in: ~s\n", [S]),
             error;
         {I, _} ->
             I
     end.
+
+-endif. % TEST

--- a/test/cleanup.erl
+++ b/test/cleanup.erl
@@ -25,13 +25,14 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
--define(local_test(TestFunc),
+-define(local_test(Timeout, TestFunc),
     fun(TestRoot) ->
         Title = erlang:atom_to_list(TestFunc),
         TestDir = filename:join(TestRoot, TestFunc),
-        {Title, fun() -> TestFunc(TestDir) end}
+        {Title, {timeout, Timeout, fun() -> TestFunc(TestDir) end}}
     end
 ).
+-define(local_test(TestFunc), ?local_test(10, TestFunc)).
 
 cleanup_test_() ->
     {foreach,
@@ -42,8 +43,8 @@ cleanup_test_() ->
             ?local_test(test_open_close),
             ?local_test(test_open_exit),
             ?local_test(test_iterator),
-            ?local_test(test_iterator_db_close),
-            ?local_test(test_iterator_exit)
+            ?local_test(15, test_iterator_db_close),
+            ?local_test(15, test_iterator_exit)
         ]
     }.
 

--- a/test/iterators.erl
+++ b/test/iterators.erl
@@ -1,8 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%%  eleveldb: Erlang Wrapper for LevelDB (http://code.google.com/p/leveldb/)
-%%
-%% Copyright (c) 2010-2013 Basho Technologies, Inc. All Rights Reserved.
+%% Copyright (c) 2013-2017 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -19,128 +17,131 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
+
 -module(iterators).
 
--compile(export_all).
-
 -ifdef(TEST).
-
 -include_lib("eunit/include/eunit.hrl").
 
 iterator_test_() ->
-    {spawn,
-     [{setup,
-       fun setup/0,
-       fun cleanup/1,
-       fun(Ref) ->
-       [
-        prev_test_case(Ref),
-        seek_and_next_test_case(Ref),
-        basic_prefetch_test_case(Ref),
-        seek_and_prefetch_test_case(Ref),
-        aae_prefetch1(Ref),
-        aae_prefetch2(Ref),
-        aae_prefetch3(Ref)
-       ]
-       end}]
-    }.
+    {spawn, [
+        {setup,
+            fun setup/0,
+            fun cleanup/1,
+            fun({_, Ref}) -> [
+                prev_test_case(Ref),
+                seek_and_next_test_case(Ref),
+                basic_prefetch_test_case(Ref),
+                seek_and_prefetch_test_case(Ref),
+                aae_prefetch1(Ref),
+                aae_prefetch2(Ref),
+                aae_prefetch3(Ref)
+            ] end
+        }]}.
 
 setup() ->
-    os:cmd("rm -rf ltest"),  % NOTE
-    {ok, Ref} = eleveldb:open("ltest", [{create_if_missing, true}]),
-    eleveldb:put(Ref, <<"a">>, <<"w">>, []),
-    eleveldb:put(Ref, <<"b">>, <<"x">>, []),
-    eleveldb:put(Ref, <<"c">>, <<"y">>, []),
-    eleveldb:put(Ref, <<"d">>, <<"z">>, []),
-    Ref.
+    Dir = eleveldb:create_test_dir(),
+    Ref = eleveldb:assert_open(Dir),
+    ?assertEqual(ok, eleveldb:put(Ref, <<"a">>, <<"w">>, [])),
+    ?assertEqual(ok, eleveldb:put(Ref, <<"b">>, <<"x">>, [])),
+    ?assertEqual(ok, eleveldb:put(Ref, <<"c">>, <<"y">>, [])),
+    ?assertEqual(ok, eleveldb:put(Ref, <<"d">>, <<"z">>, [])),
+    {Dir, Ref}.
 
-cleanup(Ref) ->
-      eleveldb:close(Ref).
+cleanup({Dir, Ref}) ->
+    eleveldb:assert_close(Ref),
+    eleveldb:delete_test_dir(Dir).
+
+assert_iterator(DbRef, ItrOpts) ->
+    ItrRet = eleveldb:iterator(DbRef, ItrOpts),
+    ?assertMatch({ok, _}, ItrRet),
+    {_, Itr} = ItrRet,
+    Itr.
 
 prev_test_case(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<>>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, next)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, prev))
+        I = assert_iterator(Ref, []),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<>>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, next)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, prev))
     end.
 
 seek_and_next_test_case(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, <<"b">>)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, next)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, next)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, next))
+        I = assert_iterator(Ref, []),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, <<"b">>)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, next)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<"a">>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, next)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, next))
     end.
 
 basic_prefetch_test_case(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<>>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch))
+        I = assert_iterator(Ref, []),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<>>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"d">>, <<"z">>}, eleveldb:iterator_move(I, prefetch))
     end.
 
 seek_and_prefetch_test_case(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, <<"b">>)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>)),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop)),
-            ?assertEqual({ok, <<"a">>, <<"w">>},eleveldb:iterator_move(I, <<"a">>))
+        I = assert_iterator(Ref, []),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, <<"b">>)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"d">>, <<"z">>}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<"a">>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<"a">>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"d">>, <<"z">>}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<"a">>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"d">>, <<"z">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<"a">>)),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"d">>, <<"z">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I, prefetch_stop)),
+        ?assertEqual({ok, <<"a">>, <<"w">>}, eleveldb:iterator_move(I, <<"a">>))
     end.
 
 aae_prefetch1(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, <<"b">>)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch_stop)),
+        I = assert_iterator(Ref, []),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, <<"b">>)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch_stop)),
 
-            {ok, J} = eleveldb:iterator(Ref, []),
-            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, <<"z">>)),
-            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, prefetch_stop))
+        J = assert_iterator(Ref, []),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(J, <<"z">>)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(J, prefetch_stop))
     end.
 
 aae_prefetch2(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({ok, <<"b">>, <<"x">>},eleveldb:iterator_move(I, <<"b">>)),
-            ?assertEqual({ok, <<"c">>, <<"y">>},eleveldb:iterator_move(I, prefetch)),
-            ?assertEqual({ok, <<"d">>, <<"z">>},eleveldb:iterator_move(I, prefetch_stop)),
+        I = assert_iterator(Ref, []),
+        ?assertEqual({ok, <<"b">>, <<"x">>}, eleveldb:iterator_move(I, <<"b">>)),
+        ?assertEqual({ok, <<"c">>, <<"y">>}, eleveldb:iterator_move(I, prefetch)),
+        ?assertEqual({ok, <<"d">>, <<"z">>}, eleveldb:iterator_move(I, prefetch_stop)),
 
-            {ok, J} = eleveldb:iterator(Ref, []),
-            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, <<"z">>)),
-            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, prefetch)),
-            ?assertEqual({error, invalid_iterator},eleveldb:iterator_move(J, prefetch_stop))
+        J = assert_iterator(Ref, []),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(J, <<"z">>)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(J, prefetch)),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(J, prefetch_stop))
     end.
 
 aae_prefetch3(Ref) ->
     fun() ->
-            {ok, I} = eleveldb:iterator(Ref, []),
-            ?assertEqual({error,invalid_iterator},eleveldb:iterator_move(I, prefetch_stop))
+        I = assert_iterator(Ref, []),
+        ?assertEqual({error, invalid_iterator}, eleveldb:iterator_move(I, prefetch_stop))
     end.
 
--endif.
+-endif. % TEST


### PR DESCRIPTION
This started with fixing tests to _NOT_ leave test files all over the place, but it quickly became apparent that many of the tests weren't running at all.

_Turn off whitespace diffs by appending `?w=1` (or `&w=1`, as appropriate) to the URL._

With these changes:

* All tests actually run, and pass.
* A few tests have been added that seemed appropriate.
* All tests write only in `/tmp` and clean up after themselves.
* All relevant cases of failures that would throw a `badmatch` are now enclosed in appropriate `?assert...` macros.
* The fundamental behavior of the tests hasn't been changed.

_Note: This does nothing about the cuttlefish kludge, sorry MvM._

This PR replaces #239 with a branch name that _should_ be compatible with all builders.