### PR TITLE
Added flag for MACOSX_DEPLOYMENT_TARGET = 10.8

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -65,6 +65,8 @@ case "$1" in
         ;;
 
     *)
+        export MACOSX_DEPLOYMENT_TARGET=10.8
+
         if [ ! -d snappy-$SNAPPY_VSN ]; then
             tar -xzf snappy-$SNAPPY_VSN.tar.gz
             (cd snappy-$SNAPPY_VSN && ./configure --disable-shared --prefix=$BASEDIR/system --libdir=$BASEDIR/system/lib --with-pic)


### PR DESCRIPTION
This value is an alternative to `-mmacosx-version-min=version` which
does not appear to be settable via the snappy configure script. This is
to allow support for historical versions of MacOSX