### PR TITLE
MacOS >= 10.14 build fix

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -6,7 +6,7 @@
 %% actually running.
 case os:type() of
     {unix,darwin} ->
-        Opt = " -mmacosx-version-min=10.8",
+        Opt = " -mmacosx-version-min=10.8 -stdlib=libc++",
         [Mjr|_] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
         Major = list_to_integer(Mjr),
         if


### PR DESCRIPTION
-stdlib=libc++ flag added for Darwin target. It fixes MACOS Mojave build.