### PR TITLE
Revert "Hack for rebar3 dep mode?"

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -14,10 +14,13 @@ SNAPPY_VSN="1.0.4"
 
 set -e
 
-DIRNAME=`dirname $0`
+if [ `basename $PWD` != "c_src" ]; then
+    # originally "pushd c_src" of bash
+    # but no need to use directory stack push here
+    cd c_src
+fi
 
-BASEDIR=`readlink -f $DIRNAME`
-cd $BASEDIR
+BASEDIR="$PWD"
 
 # detecting gmake and if exists use it
 # if not use make


### PR DESCRIPTION
What's the reason for the change?
It fails on everything non-GNU-Linux.  (And compiles completely fine with rebar3 even without it.)