### PR TITLE
Add -stdlib=libc++ flag when building snappy on develop-3.0

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -80,7 +80,7 @@ case "$1" in
         fi
 
         if [ ! -f system/lib/libsnappy.a ]; then
-            (cd snappy-$SNAPPY_VSN && $MAKE && $MAKE install)
+            (cd snappy-$SNAPPY_VSN && $MAKE -stdlib=libc++ && $MAKE -stdlib=libc++ install)
         fi
 
         


### PR DESCRIPTION
used the changes from https://github.com/basho/eleveldb/pull/258 and opened a PR again to develop-3.0