### PR TITLE
Fix git clone URL

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -56,7 +56,7 @@ case "$1" in
 
     get-deps)
         if [ ! -d leveldb ]; then
-            git clone git://github.com/basho/leveldb
+            git clone https://github.com/basho/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             if [ "$BASHO_EE" = "1" ]; then
                 (cd leveldb && git submodule update --init)
@@ -83,7 +83,7 @@ case "$1" in
         export LEVELDB_VSN="$LEVELDB_VSN"
 
         if [ ! -d leveldb ]; then
-            git clone git://github.com/basho/leveldb
+            git clone https://github.com/basho/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             if [ $BASHO_EE = "1" ]; then
                 (cd leveldb && git submodule update --init)


### PR DESCRIPTION
Starting today, we can no longer clone a repository from Github using `git://` protocol.
```
om26er@HomePC:~/scm/simplethings/eleveldb$ git clone git://github.com/basho/leveldb
Cloning into 'leveldb'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

This PR changes the code to use https instead.