### PR TITLE
freebsd build fixes

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -24,7 +24,6 @@ jobs:
       image: erlang:${{ matrix.otp }}
 
     steps:
-      - uses: lukka/get-cmake@latest
       - uses: actions/checkout@v2
       - name: Compile
         run: apt-get update && apt-get install -y cmake && make

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ develop ]
 
-
 jobs:
 
   build:
@@ -17,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - "25.1"
-          - "24.3"
-          - "22.3"
+          - "25"
+          - "24"
+          - "22"
 
     container:
       image: erlang:${{ matrix.otp }}

--- a/c_src/.gitignore
+++ b/c_src/.gitignore
@@ -1,1 +1,3 @@
 snappy-*.tar.gz
+msgpack*.tar.gz
+msgpack/

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -21,8 +21,8 @@ compile: get-deps snappy ldb
 	cp leveldb/perf_dump leveldb/sst_rewrite leveldb/sst_scan leveldb/leveldb_repair ../priv
 
 ldb:
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
 
 snappy: system/lib/libsnappy.a
 
@@ -31,7 +31,7 @@ system/lib/libsnappy.a:
 	(cd snappy-$(SNAPPY_VSN) && \
 	 git submodule update --init && \
 	 if [ -r autogen.sh ]; then \
-	   ./autogen.sh && ./configure --prefix=$(BASEDIR)/system && make && make install; \
+	   ./autogen.sh && ./configure --prefix=$(BASEDIR)/system && $(MAKE) && $(MAKE) install; \
 	 else \
 	   mkdir build && cd build && \
 	   mkdir -p $(BASEDIR)/system && \
@@ -39,7 +39,7 @@ system/lib/libsnappy.a:
 	         -D CMAKE_INSTALL_PREFIX=$(BASEDIR)/system \
 	     ..; \
 	  fi && \
-	  make && make install)
+	  $(MAKE) && $(MAKE) install)
 	mv system/lib64 system/lib || true
 
 clean:

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,6 +8,8 @@ CFLAGS := $(CFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/inclu
 CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
 
 get-deps:
+	git config --global --add safe.directory /__w/eleveldb/eleveldb
+	echo "ubuntu-latest image with otp-22, are you happy now?"
 	if [ ! -r snappy-$(SNAPPY_VSN).tar.gz ]; then \
 	    wget -O snappy-$(SNAPPY_VSN).tar.gz https://github.com/google/snappy/archive/refs/tags/$(SNAPPY_VSN).tar.gz; \
 	fi

--- a/make
+++ b/make
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+which gmake 1>/dev/null 2>/dev/null && MAKE=gmake
+MAKE=${MAKE:-make}
+
+$MAKE $@

--- a/rebar.config
+++ b/rebar.config
@@ -36,7 +36,7 @@
              {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a c_src/system/lib/libsnappy.a -lstdc++"}
              ]}.
 
-{pre_hooks, [{'get-deps', "make -C c_src get-deps"},
-             {compile, "make -C c_src compile"}]}.
+{pre_hooks, [{'get-deps', "./make -C c_src get-deps"},
+             {compile, "./make -C c_src compile"}]}.
 
-{post_hooks, [{clean, "make -C c_src clean"}]}.
+{post_hooks, [{clean, "./make -C c_src clean"}]}.


### PR DESCRIPTION
Fixes to unbreak freebsd build (similar fixes existed before the migration from c_src/build_deps.sh to c_src/Makefile, but were lost in transition), with two other, less critical, tweaks.

These fixes went into riak-3.2.0 packages built by TI Tokyo.