### PR TITLE
Depend on system snappy

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -29,7 +29,7 @@ jobs:
         run: apt-get update && apt-get install -y cmake && make
       - name: Run tests
         run: apt-get update && apt-get install -y cmake libc6-dev && make check
-      - name: rebar3 compile 
+      - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer
         run: ./rebar3 do xref, dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Compile
-        run: apt-get update && apt-get install -y cmake libsnappy-dev && make
+        run: apt-get update && apt-get install -y libsnappy-dev && make
       - name: Run tests
-        run: apt-get update && apt-get install -y cmake libsnappy-dev libc6-dev && make check
+        run: apt-get update && apt-get install -y libsnappy-dev libc6-dev && make check
       - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Compile
-        run: apt-get update && apt-get install -y cmake && make
+        run: apt-get update && apt-get install -y cmake libsnappy-dev && make
       - name: Run tests
-        run: apt-get update && apt-get install -y cmake libc6-dev && make check
+        run: apt-get update && apt-get install -y cmake libsnappy-dev libc6-dev && make check
       - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,5 +1,4 @@
 LEVELDB_VSN ?= "2.0.38"
-SNAPPY_VSN ?= "1.1.9"
 BASEDIR = $(shell pwd)
 
 LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
@@ -10,43 +9,22 @@ CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/i
 get-deps:
 	git config --global --add safe.directory /__w/eleveldb/eleveldb
 	echo "ubuntu-latest image with otp-22, are you happy now?"
-	if [ ! -r snappy-$(SNAPPY_VSN).tar.gz ]; then \
-	    wget -O snappy-$(SNAPPY_VSN).tar.gz https://github.com/google/snappy/archive/refs/tags/$(SNAPPY_VSN).tar.gz; \
-	fi
 	if [ ! -d leveldb ]; then \
 	    git clone https://github.com/basho/leveldb && \
 	    (cd leveldb && git checkout $(LEVELDB_VSN)) && \
 	    (cd leveldb && git submodule update --init); \
 	fi
 
-compile: get-deps snappy ldb
+compile: get-deps ldb
 	cp leveldb/perf_dump leveldb/sst_rewrite leveldb/sst_scan leveldb/leveldb_repair ../priv
 
 ldb:
 	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
 	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
 
-snappy: system/lib/libsnappy.a
-
-system/lib/libsnappy.a:
-	tar -xzf snappy-$(SNAPPY_VSN).tar.gz && \
-	(cd snappy-$(SNAPPY_VSN) && \
-	 git submodule update --init && \
-	 if [ -r autogen.sh ]; then \
-	   ./autogen.sh && ./configure --prefix=$(BASEDIR)/system && $(MAKE) && $(MAKE) install; \
-	 else \
-	   mkdir build && cd build && \
-	   mkdir -p $(BASEDIR)/system && \
-	   cmake -D SNAPPY_BUILD_TESTS=0 -D SNAPPY_BUILD_BENCHMARKS=0 \
-	         -D CMAKE_INSTALL_PREFIX=$(BASEDIR)/system \
-	     ..; \
-	  fi && \
-	  $(MAKE) && $(MAKE) install)
-	mv system/lib64 system/lib || true
-
 clean:
 	$(MAKE) -C leveldb clean
-	rm -rf system snappy-$(SNAPPY_VSN)/build
+	rm -rf system
 
 test: compile
 	$(MAKE) CXXFLAGS="$(CXXFLAGS) -Wno-narrowing" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -10,9 +10,8 @@ get-deps:
 	git config --global --add safe.directory /__w/eleveldb/eleveldb
 	echo "ubuntu-latest image with otp-22, are you happy now?"
 	if [ ! -d leveldb ]; then \
-	    git clone https://github.com/basho/leveldb && \
-	    (cd leveldb && git checkout $(LEVELDB_VSN)) && \
-	    (cd leveldb && git submodule update --init); \
+	    git clone --depth=1 --branch=$(LEVELDB_VSN) https://github.com/basho/leveldb && \
+	    (cd leveldb && git submodule update --depth 1 --init); \
 	fi
 
 compile: get-deps ldb

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
              {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
              {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC"},
              {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb -I c_src/system/include"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a c_src/system/lib/libsnappy.a -lstdc++"}
+             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
              ]}.
 
 {pre_hooks, [{'get-deps', "./make -C c_src get-deps"},


### PR DESCRIPTION
Rather than downloading and building snappy, depend on libsnappy preinstalled on the host system.

Also, use `--depth=1` when cloning leveldb.