### PR TITLE
Depend on system snappy (With OSX fix)

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -29,7 +29,7 @@ jobs:
         run: apt-get update && apt-get install -y cmake && make
       - name: Run tests
         run: apt-get update && apt-get install -y cmake libc6-dev && make check
-      - name: rebar3 compile 
+      - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer
         run: ./rebar3 do xref, dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Compile
-        run: apt-get update && apt-get install -y cmake libsnappy-dev && make
+        run: apt-get update && apt-get install -y libsnappy-dev && make
       - name: Run tests
-        run: apt-get update && apt-get install -y cmake libsnappy-dev libc6-dev && make check
+        run: apt-get update && apt-get install -y libsnappy-dev libc6-dev && make check
       - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -23,14 +23,14 @@ jobs:
         # OTP lower than 23 does not run on ubuntu-latest (22.04), see
         # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
         exclude:
-          - otp_version: 22
+          - otp: 22
             os: ubuntu-latest
-          - otp_version: 23
+          - otp: 23
             os: ubuntu-latest
         include:
-          - otp_version: 22
+          - otp: 22
             os: ubuntu-20.04
-          - otp_version: 23
+          - otp: 23
             os: ubuntu-20.04
 
     steps:

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -36,11 +36,24 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Cache rebar3
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/rebar3
+          key: ${{runner.os}}-rebar3-cache-${{matrix.otp}}-v2-${{ hashFiles(format('rebar.lock')) }}
       - name: Install dependencies (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           sudo apt-get -qq update
           sudo apt-get -qq install libsnappy-dev libc6-dev
+      - name: Configure Homebrew cache
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/
+            ~/Library/Caches/Homebrew/downloads/
+          key: brew-${{ runner.os }}-${{ matrix.otp  }}
       - name: Install Dependencies (OSX)
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: |

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -2,33 +2,61 @@ name: Erlang CI
 
 on:
   push:
-    branches: [ develop ]
+    branches: [develop]
   pull_request:
-    branches: [ develop ]
+    branches: [develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-
   build:
-
-    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.os }} with OTP ${{ matrix.otp }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        otp:
-          - "25"
-          - "24"
-          - "22"
-
-    container:
-      image: erlang:${{ matrix.otp }}
+        otp: [22, 23, 24, 25]
+        os: [ubuntu-latest, macos-latest]
+        # OTP lower than 23 does not run on ubuntu-latest (22.04), see
+        # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
+        exclude:
+          - otp_version: 22
+            os: ubuntu-latest
+          - otp_version: 23
+            os: ubuntu-latest
+        include:
+          - otp_version: 22
+            os: ubuntu-20.04
+          - otp_version: 23
+            os: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install dependencies (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install libsnappy-dev libc6-dev
+      - name: Install Dependencies (OSX)
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          export majorversion="$(cut -d '.' -f 1 <<< "${{ matrix.otp }}")"
+          brew install coreutils erlang@$majorversion snappy
+      - name: Install Erlang/OTP
+        # setup beam doesn't provide MacOS packages
+        # we use Homebrew to instal them
+        if: ${{ !startsWith(matrix.os , 'macos') }}
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
       - name: Compile
-        run: apt-get update && apt-get install -y libsnappy-dev && make
+        run: make
       - name: Run tests
-        run: apt-get update && apt-get install -y libsnappy-dev libc6-dev && make check
+        run: make check
       - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -55,12 +55,8 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
       - name: Compile
-        run: make
-      - name: Run tests
-        run: make check
-      - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer
         run: ./rebar3 do xref, dialyzer
-      - name: Run eunit
+      - name: Run tests
         run: ./rebar3 as gha do eunit

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Compile
-        run: apt-get update && apt-get install -y cmake && make
+        run: apt-get update && apt-get install -y cmake libsnappy-dev && make
       - name: Run tests
-        run: apt-get update && apt-get install -y cmake libc6-dev && make check
+        run: apt-get update && apt-get install -y cmake libsnappy-dev libc6-dev && make check
       - name: rebar3 compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           export majorversion="$(cut -d '.' -f 1 <<< "${{ matrix.otp }}")"
           brew install coreutils erlang@$majorversion snappy
+          echo "/usr/local/opt/erlang@$majorversion/bin" >> $GITHUB_PATH
       - name: Install Erlang/OTP
         # setup beam doesn't provide MacOS packages
         # we use Homebrew to instal them

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ cover: test
 	$(REBAR) cover
 
 test: compile
-	$(MAKE) -C c_src test
 	$(REBAR) as test do eunit
 
 dialyzer:

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,12 +1,11 @@
 LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
-LDFLAGS := $(LDFLAGS)
-LD_LIBRARY_PATH := $(LD_LIBRARY_PATH)
-CFLAGS := $(CFLAGS) -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/leveldb/include -fPIC
+CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
+CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
 
 ifeq ($(shell uname -s), Darwin)
+
 	# OSX with homebrew
   HAS_BREW := $(shell command -v brew;)
 
@@ -33,11 +32,11 @@ compile: get-deps ldb
 
 ldb:
 	@echo "Building LevelDB..."
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb all
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb tools
 
 clean:
 	$(MAKE) -C leveldb clean
 
 test: compile
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,7 +2,7 @@ LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
 CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wnarrowing
+CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wno-narrowing
 
 ifeq ($(shell uname -s), Darwin)
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,7 +1,7 @@
 LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
-CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
+CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wnarrowing
 CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wnarrowing
 
 ifeq ($(shell uname -s), Darwin)

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,5 +1,4 @@
 LEVELDB_VSN ?= "2.0.38"
-SNAPPY_VSN ?= "1.1.9"
 BASEDIR = $(shell pwd)
 
 LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
@@ -10,43 +9,22 @@ CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/i
 get-deps:
 	git config --global --add safe.directory /__w/eleveldb/eleveldb
 	echo "ubuntu-latest image with otp-22, are you happy now?"
-	if [ ! -r snappy-$(SNAPPY_VSN).tar.gz ]; then \
-	    wget -O snappy-$(SNAPPY_VSN).tar.gz https://github.com/google/snappy/archive/refs/tags/$(SNAPPY_VSN).tar.gz; \
-	fi
 	if [ ! -d leveldb ]; then \
 	    git clone https://github.com/basho/leveldb && \
 	    (cd leveldb && git checkout $(LEVELDB_VSN)) && \
 	    (cd leveldb && git submodule update --init); \
 	fi
 
-compile: get-deps snappy ldb
+compile: get-deps ldb
 	cp leveldb/perf_dump leveldb/sst_rewrite leveldb/sst_scan leveldb/leveldb_repair ../priv
 
 ldb:
 	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
 	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
 
-snappy: system/lib/libsnappy.a
-
-system/lib/libsnappy.a:
-	tar -xzf snappy-$(SNAPPY_VSN).tar.gz && \
-	(cd snappy-$(SNAPPY_VSN) && \
-	 git submodule update --init && \
-	 if [ -r autogen.sh ]; then \
-	   ./autogen.sh && ./configure --prefix=$(BASEDIR)/system && $(MAKE) && $(MAKE) install; \
-	 else \
-	   mkdir build && cd build && \
-	   mkdir -p $(BASEDIR)/system && \
-	   cmake -D SNAPPY_BUILD_TESTS=0 -D SNAPPY_BUILD_BENCHMARKS=0 \
-	         -D CMAKE_INSTALL_PREFIX=$(BASEDIR)/system \
-	     ..; \
-	  fi && \
-	  $(MAKE) && $(MAKE) install)
-	mv system/lib64 system/lib || true
-
 clean:
 	$(MAKE) -C leveldb clean
-	rm -rf system snappy-$(SNAPPY_VSN)/build
+	rm -rf system
 
 test: compile
 	$(MAKE) CXXFLAGS="$(CXXFLAGS) -Wno-narrowing" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -10,9 +10,8 @@ get-deps:
 	git config --global --add safe.directory /__w/eleveldb/eleveldb
 	echo "ubuntu-latest image with otp-22, are you happy now?"
 	if [ ! -d leveldb ]; then \
-	    git clone https://github.com/basho/leveldb && \
-	    (cd leveldb && git checkout $(LEVELDB_VSN)) && \
-	    (cd leveldb && git submodule update --init); \
+	    git clone --depth=1 --branch=$(LEVELDB_VSN) https://github.com/basho/leveldb && \
+	    (cd leveldb && git submodule update --depth 1 --init); \
 	fi
 
 compile: get-deps ldb

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,9 +1,18 @@
 LEVELDB_VSN ?= "2.0.38"
-BASEDIR = $(shell pwd)
+C_SRC_DIR := $(shell pwd)
+PROJECT_DIR := $(abspath $(C_SRC_DIR)/..)
+TARGET_DIR := $(PROJECT_DIR)/priv/
 
-LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
-CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
+# LevelDB tools
+TOOLS = \
+	leveldb_repair \
+	perf_dump \
+	sst_rewrite \
+	sst_scan
+
+LDFLAGS := $(LDFLAGS) -lpthread
+CFLAGS := $(CFLAGS) -I. -I $(C_SRC_DIRC_SRC_DIR)/leveldb/include -fPIC
+CXXFLAGS := $(CXXFLAGS) -I. -I $(C_SRC_DIR)/leveldb/include -fPIC
 TEST_CXXFLAGS := $(CXXFLAGS) -Wno-narrowing
 
 ifeq ($(shell uname -s), Darwin)
@@ -33,15 +42,16 @@ get-deps:
 	fi
 
 compile: get-deps ldb
-	cp leveldb/perf_dump leveldb/sst_rewrite leveldb/sst_scan leveldb/leveldb_repair ../priv
+	for tool in $(TOOLS); do cp leveldb/$$tool $(TARGET_DIR); done
 
 ldb:
 	@echo "Building LevelDB..."
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
+	$(MAKE) LDFLAGS="" -C leveldb all
+	$(MAKE) LDFLAGS="$(LDFLAGS)" -C leveldb tools
 
 clean:
 	$(MAKE) -C leveldb clean
+	for tool in $(TOOLS); do rm -f $(TARGET_DIR)$$tool; done
 
 test: compile
-	$(MAKE) PLATFORM_CXXFLAGS="$(TEST_CXXFLAGS)" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test
+	$(MAKE) LDFLAGS="$(LDFLAGS)" CXXFLAGS="$(CXXFLAGS)" CFLAGS="$(CFLAGS)" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,10 +1,24 @@
 LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
-LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
-LD_LIBRARY_PATH := $(BASEDIR)/system/lib:$(LD_LIBRARY_PATH)
-CFLAGS := $(CFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/system/include -I. -I $(BASEDIR)/leveldb/include -fPIC
+LDFLAGS := $(LDFLAGS)
+LD_LIBRARY_PATH := $(LD_LIBRARY_PATH)
+CFLAGS := $(CFLAGS) -I $(BASEDIR)/leveldb/include -fPIC
+CXXFLAGS := $(CXXFLAGS) -I $(BASEDIR)/leveldb/include -fPIC
+
+ifeq ($(shell uname -s), Darwin)
+	# OSX with homebrew
+  HAS_BREW := $(shell command -v brew;)
+
+	ifdef HAS_BREW
+		SNAPPY_DIR ?= $(shell brew --prefix snappy)
+	endif
+
+	# Default dir (Mac ports)
+	SNAPPY_DIR ?= /usr/local/opt/snappy
+
+  LDFLAGS += -L${SNAPPY_DIR}/lib
+endif
 
 get-deps:
 	git config --global --add safe.directory /__w/eleveldb/eleveldb
@@ -18,12 +32,12 @@ compile: get-deps ldb
 	cp leveldb/perf_dump leveldb/sst_rewrite leveldb/sst_scan leveldb/leveldb_repair ../priv
 
 ldb:
+	@echo "Building LevelDB..."
 	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
 	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
 
 clean:
 	$(MAKE) -C leveldb clean
-	rm -rf system
 
 test: compile
-	$(MAKE) CXXFLAGS="$(CXXFLAGS) -Wno-narrowing" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -10,7 +10,7 @@ TOOLS = \
 	sst_rewrite \
 	sst_scan
 
-LDFLAGS := $(LDFLAGS) -lpthread
+LDFLAGS := $(LDFLAGS) -lsnappy -lpthread
 CFLAGS := $(CFLAGS) -I. -I $(C_SRC_DIRC_SRC_DIR)/leveldb/include -fPIC
 CXXFLAGS := $(CXXFLAGS) -I. -I $(C_SRC_DIR)/leveldb/include -fPIC
 TEST_CXXFLAGS := $(CXXFLAGS) -Wno-narrowing

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,8 +1,11 @@
 LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
+LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
+LD_LIBRARY_PATH=$(BASEDIR)/system/lib:$(LD_LIBRARY_PATH)
 CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wno-narrowing
+CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
+TEST_CXXFLAGS := $(CXXFLAGS) -Wno-narrowing
 
 ifeq ($(shell uname -s), Darwin)
 
@@ -19,7 +22,7 @@ ifeq ($(shell uname -s), Darwin)
   LDFLAGS += -L${SNAPPY_DIR}/lib
 
 	# Resolves C++11 narrowing error on Mac OS
-	CXXFLAGS += -Wno-c++11-narrowing
+	TEST_CXXFLAGS += -Wno-c++11-narrowing
 endif
 
 get-deps:
@@ -35,11 +38,11 @@ compile: get-deps ldb
 
 ldb:
 	@echo "Building LevelDB..."
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb all
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb tools
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb all
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb tools
 
 clean:
 	$(MAKE) -C leveldb clean
 
 test: compile
-	$(MAKE) PLATFORM_CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb test
+	$(MAKE) PLATFORM_CXXFLAGS="$(TEST_CXXFLAGS)" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" LD_LIBRARY_PATH="$(LD_LIBRARY_PATH)" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,7 +1,7 @@
 LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
-CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wnarrowing
+CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
 CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wnarrowing
 
 ifeq ($(shell uname -s), Darwin)
@@ -17,6 +17,9 @@ ifeq ($(shell uname -s), Darwin)
 	SNAPPY_DIR ?= /usr/local/opt/snappy
 
   LDFLAGS += -L${SNAPPY_DIR}/lib
+
+	# Resolves C++11 narrowing error on Mac OS
+	CXXFLAGS += -Wno-c++11-narrowing
 endif
 
 get-deps:
@@ -39,4 +42,4 @@ clean:
 	$(MAKE) -C leveldb clean
 
 test: compile
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread -Wnarrowing" -C leveldb test
+	$(MAKE) PLATFORM_CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,7 +2,7 @@ LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
 CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
-CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
+CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC -Wnarrowing
 
 ifeq ($(shell uname -s), Darwin)
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -39,4 +39,4 @@ clean:
 	$(MAKE) -C leveldb clean
 
 test: compile
-	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread" -C leveldb test
+	$(MAKE) LDFLAGS="$(LDFLAGS) -lsnappy -lpthread -Wnarrowing" -C leveldb test

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,7 +2,6 @@ LEVELDB_VSN ?= "2.0.38"
 BASEDIR = $(shell pwd)
 
 LDFLAGS := $(LDFLAGS) -L$(BASEDIR)/system/lib
-LD_LIBRARY_PATH=$(BASEDIR)/system/lib:$(LD_LIBRARY_PATH)
 CFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
 CXXFLAGS += -I $(BASEDIR)/leveldb/include -fPIC
 TEST_CXXFLAGS := $(CXXFLAGS) -Wno-narrowing

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -54,4 +54,4 @@ clean:
 	for tool in $(TOOLS); do rm -f $(TARGET_DIR)$$tool; done
 
 test: compile
-	$(MAKE) LDFLAGS="$(LDFLAGS)" CXXFLAGS="$(CXXFLAGS)" CFLAGS="$(CFLAGS)" -C leveldb test
+	$(MAKE) LDFLAGS="$(LDFLAGS)" CXXFLAGS="$(TEST_CXXFLAGS)" CFLAGS="$(CFLAGS)" -C leveldb test

--- a/make
+++ b/make
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-which gmake 1>/dev/null 2>/dev/null && MAKE=gmake
-MAKE=${MAKE:-make}
-
-$MAKE $@

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
          %% Make sure to set -fPIC when compiling leveldb
              {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
              {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC"},
-             {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb -I c_src/system/include"},
+             {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb"},
              {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++"}
              ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -5,19 +5,20 @@
 
 {plugins, [{eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}, pc]}.
 
-{provider_hooks,
- [
-  {post,
-   [
-    {compile, {pc, compile}},
-    {clean, {pc, clean}}
-   ]
-  }
- ]
-}.
+{provider_hooks, [
+    {post, [
+        {compile, {pc, compile}},
+        {clean, {pc, clean}}
+    ]}
+]}.
 
-{xref_checks,[undefined_function_calls,undefined_functions,locals_not_used,
-    deprecated_function_calls, deprecated_functions]}.
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used,
+    deprecated_function_calls,
+    deprecated_functions
+]}.
 
 {erl_opts, [warnings_as_errors, debug_info]}.
 
@@ -25,19 +26,26 @@
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.
 
-{port_specs, [{ "priv/eleveldb.so", ["c_src/*.cc"] }]}.
+{port_specs, [{"priv/eleveldb.so", ["c_src/*.cc"]}]}.
 
 {artifacts, ["priv/eleveldb.so"]}.
 
 {port_env, [
-         %% Make sure to set -fPIC when compiling leveldb
-             {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
-             {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC"},
-             {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++"}
-             ]}.
+    %% Make sure to set -fPIC when compiling leveldb
+    {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -I c_src/leveldb/include -I c_src/leveldb"},
+    {"LDFLAGS", "$LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
+]}.
 
-{pre_hooks, [{'get-deps', "./make -C c_src get-deps"},
-             {compile, "./make -C c_src compile"}]}.
+{pre_hooks, [
+    {"(linux|darwin|solaris)", 'get-deps', "./make -C c_src get-deps"},
+    {"(freebsd|netbsd|openbsd)", 'get-deps', "gmake -C c_src get-deps"},
+    {"(linux|darwin|solaris)", compile, "make -C c_src compile"},
+    {"(freebsd|netbsd|openbsd)", compile, "gmake -C c_src compile"},
+    {"(linux|darwin|solaris)", eunit, "make -C c_src test"},
+    {"(freebsd|netbsd|openbsd)", eunit, "gmake -C c_src test"}
+]}.
 
-{post_hooks, [{clean, "./make -C c_src clean"}]}.
+{post_hooks, [
+    {"(linux|darwin|solaris)", clean, "make -C c_src clean"},
+    {"(freebsd|netbsd|openbsd)", clean, "gmake -C c_src clean"}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,6 @@
 {minimum_otp_vsn, "22.0"}.
 
 {eunit_opts, [verbose]}.
-{so_name, "eleveldb.so"}.
 
 {plugins, [{eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}, pc]}.
 
@@ -20,20 +19,22 @@
 {xref_checks,[undefined_function_calls,undefined_functions,locals_not_used,
     deprecated_function_calls, deprecated_functions]}.
 
-{port_sources, ["c_src/*.cc"]}.
-
 {erl_opts, [warnings_as_errors, debug_info]}.
 
 {profiles, [
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.
 
+{port_specs, [{ "priv/eleveldb.so", ["c_src/*.cc"] }]}.
+
+{artifacts, ["priv/eleveldb.so"]}.
+
 {port_env, [
          %% Make sure to set -fPIC when compiling leveldb
              {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
              {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC"},
              {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb -I c_src/system/include"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
+             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++"}
              ]}.
 
 {pre_hooks, [{'get-deps', "./make -C c_src get-deps"},

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
              {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
              {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC"},
              {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb -I c_src/system/include"},
-             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a c_src/system/lib/libsnappy.a -lstdc++"}
+             {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
              ]}.
 
 {pre_hooks, [{'get-deps', "./make -C c_src get-deps"},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -6,12 +6,19 @@
 %% actually running.
 case os:type() of
     {unix,darwin} ->
-        Opt = " -mmacosx-version-min=10.8 -stdlib=libc++",
+        DefaultOpt = " -mmacosx-version-min=10.8 -stdlib=libc++",
+        Opt = case os:find_executable("brew") of
+            false ->
+                DefaultOpt;
+            _Brew ->
+                HomebrewPrefix = string:trim(os:cmd("brew --prefix")),
+                DefaultOpt ++ " -L" ++ HomebrewPrefix ++ "/lib"
+        end,
         [Mjr|_] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
         Major = list_to_integer(Mjr),
         if
             Major >= 13 ->
-                Flags = ["CFLAGS", "CXXFLAGS", "DRV_CFLAGS", "DRV_LDFLAGS"],
+                Flags = ["CFLAGS", "CXXFLAGS", "LDFLAGS"],
                 {port_env, Vals} = lists:keyfind(port_env, 1, CONFIG),
                 Fold = fun({Flag,Val}, Acc) ->
                                case lists:member(Flag, Flags) of

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,37 +1,42 @@
 %%-*- mode: erlang -*-
 
+AddPortEnv = fun(Config, Flags, NewValue) ->
+    {port_env, Vals} = lists:keyfind(port_env, 1, Config),
+    Fold = fun({Flag, Val}, Acc) ->
+        case lists:member(Flag, Flags) of
+            true ->
+                [{Flag, Val ++ NewValue} | Acc];
+            false ->
+                Acc
+        end
+    end,
+    NewVals = lists:foldl(Fold, [], Vals),
+    lists:keyreplace(port_env, 1, Config, {port_env, NewVals})
+end.
+
 %% Set the minimum Mac target to 10.8 for 10.9 or greater.  This runtime
 %% check is needed since rebar's system_architecture check looks only at
 %% the version of the OS used to build the Erlang runtime, not the version
 %% actually running.
 case os:type() of
-    {unix,darwin} ->
-        DefaultOpt = " -mmacosx-version-min=10.8 -stdlib=libc++",
-        Opt = case os:find_executable("brew") of
-            false ->
-                DefaultOpt;
-            _Brew ->
-                HomebrewPrefix = string:trim(os:cmd("brew --prefix")),
-                DefaultOpt ++ " -L" ++ HomebrewPrefix ++ "/lib"
-        end,
-        [Mjr|_] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
+    {unix, darwin} ->
+        NewerOsxOpts = " -mmacosx-version-min=10.8 -stdlib=libc++",
+        BrewLibsOpts =
+            case os:find_executable("brew") of
+                false ->
+                    "";
+                _Brew ->
+                    HomebrewPrefix = string:trim(os:cmd("brew --prefix")),
+                    " -L" ++ HomebrewPrefix ++ "/lib"
+            end,
+        [Mjr | _] = string:tokens(os:cmd("/usr/bin/uname -r"), "."),
         Major = list_to_integer(Mjr),
+        Flags = ["CFLAGS", "CXXFLAGS", "LDFLAGS"],
         if
             Major >= 13 ->
-                Flags = ["CFLAGS", "CXXFLAGS", "LDFLAGS"],
-                {port_env, Vals} = lists:keyfind(port_env, 1, CONFIG),
-                Fold = fun({Flag,Val}, Acc) ->
-                               case lists:member(Flag, Flags) of
-                                   true ->
-                                      [{Flag, Val++Opt}|Acc];
-                                   false ->
-                                       Acc
-                               end
-                       end,
-                NewVals = lists:foldl(Fold, [], Vals),
-                lists:keyreplace(port_env, 1, CONFIG, {port_env, NewVals});
+                AddPortEnv(CONFIG, Flags, NewerOsxOpts ++ BrewLibsOpts);
             true ->
-                CONFIG
+                AddPortEnv(CONFIG, Flags, BrewLibsOpts)
         end;
     _ ->
         CONFIG


### PR DESCRIPTION
This builds on top of @hmmr 's  https://github.com/basho/eleveldb/pull/271.

* Fixes compilation in OSX
* Adds OSX tests to CI
* Add some port compiler cleanup on the `rebar.config`, it was using the old config style

Fixes https://github.com/basho/eleveldb/issues/270