### PR TITLE
Introduce rebar3_external plugin to handle leveldb source code

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,4 +1,4 @@
-LEVELDB_VSN ?= "2.0.38"
+LEVELDB_SRC := $(REBAR_DEPS_DIR)/leveldb/c_src
 C_SRC_DIR := $(shell pwd)
 PROJECT_DIR := $(abspath $(C_SRC_DIR)/..)
 TARGET_DIR := $(PROJECT_DIR)/priv/
@@ -11,8 +11,8 @@ TOOLS = \
 	sst_scan
 
 LDFLAGS := $(LDFLAGS) -lsnappy -lpthread
-CFLAGS := $(CFLAGS) -I. -I $(C_SRC_DIRC_SRC_DIR)/leveldb/include -fPIC
-CXXFLAGS := $(CXXFLAGS) -I. -I $(C_SRC_DIR)/leveldb/include -fPIC
+CFLAGS := $(CFLAGS) -I. -I $(LEVELDB_SRC)/include -fPIC
+CXXFLAGS := $(CXXFLAGS) -I. -I $(LEVELDB_SRC)/include -fPIC
 TEST_CXXFLAGS := $(CXXFLAGS) -Wno-narrowing
 
 ifeq ($(shell uname -s), Darwin)
@@ -33,25 +33,17 @@ ifeq ($(shell uname -s), Darwin)
 	TEST_CXXFLAGS += -Wno-c++11-narrowing
 endif
 
-get-deps:
-	git config --global --add safe.directory /__w/eleveldb/eleveldb
-	echo "ubuntu-latest image with otp-22, are you happy now?"
-	if [ ! -d leveldb ]; then \
-	    git clone --depth=1 --branch=$(LEVELDB_VSN) https://github.com/basho/leveldb && \
-	    (cd leveldb && git submodule update --depth 1 --init); \
-	fi
-
-compile: get-deps ldb
-	for tool in $(TOOLS); do cp leveldb/$$tool $(TARGET_DIR); done
+compile: ldb
+	for tool in $(TOOLS); do cp $(LEVELDB_SRC)/$$tool $(TARGET_DIR); done
 
 ldb:
 	@echo "Building LevelDB..."
-	$(MAKE) LDFLAGS="" -C leveldb all
-	$(MAKE) LDFLAGS="$(LDFLAGS)" -C leveldb tools
+	$(MAKE) LDFLAGS="" -C $(LEVELDB_SRC) all
+	$(MAKE) LDFLAGS="$(LDFLAGS)" -C $(LEVELDB_SRC) tools
 
 clean:
-	$(MAKE) -C leveldb clean
+	$(MAKE) -C $(LEVELDB_SRC) clean
 	for tool in $(TOOLS); do rm -f $(TARGET_DIR)$$tool; done
 
 test: compile
-	$(MAKE) LDFLAGS="$(LDFLAGS)" CXXFLAGS="$(TEST_CXXFLAGS)" CFLAGS="$(CFLAGS)" -C leveldb test
+	$(MAKE) LDFLAGS="$(LDFLAGS)" CXXFLAGS="$(TEST_CXXFLAGS)" CFLAGS="$(CFLAGS)" -C $(LEVELDB_SRC) test

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,19 @@
 
 {eunit_opts, [verbose]}.
 
-{plugins, [{eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}}, pc]}.
+{plugins, [
+    {eqc_rebar, {git, "https://github.com/Quviq/eqc-rebar", {branch, "master"}}},
+    pc,
+    rebar3_external
+]}.
+
+{deps, [
+    {leveldb,
+        {external, {git, "https://github.com/basho/leveldb", {tag, "2.0.38"}}, "c_src", [
+            {description, "leveldb: A key-value store"},
+            {vsn, "2.0.38"}
+        ]}}
+]}.
 
 {provider_hooks, [
     {post, [
@@ -32,13 +44,11 @@
 
 {port_env, [
     %% Make sure to set -fPIC when compiling leveldb
-    {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -I c_src/leveldb/include -I c_src/leveldb"},
-    {"LDFLAGS", "$LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
+    {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC -I $REBAR_DEPS_DIR/leveldb/c_src/include -I $REBAR_DEPS_DIR/leveldb/c_src"},
+    {"LDFLAGS", "$LDFLAGS $REBAR_DEPS_DIR/leveldb/c_src/libleveldb.a -lsnappy -lstdc++"}
 ]}.
 
 {pre_hooks, [
-    {"(linux|darwin|solaris)", 'get-deps', "./make -C c_src get-deps"},
-    {"(freebsd|netbsd|openbsd)", 'get-deps', "gmake -C c_src get-deps"},
     {"(linux|darwin|solaris)", compile, "make -C c_src compile"},
     {"(freebsd|netbsd|openbsd)", compile, "gmake -C c_src compile"},
     {"(linux|darwin|solaris)", eunit, "make -C c_src test"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,5 @@
-[].
+[{<<"leveldb">>,
+  {external,{git,"https://github.com/basho/leveldb",{tag,"2.0.38"}},
+            "c_src",
+            [{description,"leveldb: A key-value store"},{vsn,"2.0.38"}]},
+  0}].


### PR DESCRIPTION
Currently [1], rebar3 does not support adding hooks for 'get-deps'. That is why the compile rule in c_src/Makefile has also to call get_deps makefile rule in order to fetch leveldb source code. The whole process works but can be improved.

This change introduces a plugin called rebar3_external which deals with external source code like leveldb source code. That way rebar3 can perform dependency manager without relies on makefiles or scripts.

The intend is to have leveldb source code managed by rebar3. So, one could easily upgrade it just bumping the leveldb version in the rebar3.config file.

1: https://github.com/erlang/rebar3/issues/2784